### PR TITLE
Auto-generate footer year dynamically: replaced hardcoded year wit…

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -145,7 +145,7 @@ const LoginPage = () => {
           </Link>
         </Typography>
         <Typography variant="body2" sx={{ marginTop: '10px' }}>
-          © 2024 KubeEdge Community
+          © {new Date().getFullYear()} KubeEdge Community
         </Typography>
       </Box>
     </Box>


### PR DESCRIPTION

**What type of PR is this?**  
<!--  
Add one of the following kinds:  
/kind bug  
/kind cleanup  
/kind documentation  
/kind feature  
/kind test  
/kind design  

Optionally add one or more of the following kinds if applicable:  
/kind api-change  
/kind failing-test  ailing-test  
-->  
/kind feature

**What this PR does / why we need it**:  
This PR updates the footer section to automatically display the current year instead of a hardcoded value. This improves maintainability and ensures the copyright information is always accurate without manual updates.  

**Which issue(s) this PR fixes**:  
<!--  
*Automatically closes linked issue when PR is merged.  
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.  
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*  
-->  
Fixes #41  

**Screenshot**:  
![image](https://github.com/user-attachments/assets/82628af6-e451-437b-80fd-5aef919e58cc)
**Does this PR introduce a user-facing change?**:  
<!--  
If no, just write "NONE" in the release-note block below.  
If yes, a release note is required:  
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".  
-->  

```release-note  
The footer now dynamically displays the current year instead of a hardcoded value.  
```