### PR TITLE
fix: making full menu item clickable

### DIFF
--- a/modules/web/src/component/SideNav/index.tsx
+++ b/modules/web/src/component/SideNav/index.tsx
@@ -29,6 +29,7 @@ interface SideNavProps {
 interface ListItemLinkProps extends ListItemProps {
   open?: boolean;
   item?: NavMenuItem;
+  onToggle?: () => void;
 }
 
 function ListItemLink(props: ListItemLinkProps) {
@@ -39,17 +40,16 @@ function ListItemLink(props: ListItemLinkProps) {
 
   if (props.item?.link) {
     return (
-      <Link href={props.item.link}>
+      <ListItemButton component={Link as any} href={props.item.link}>
         <ListItemText primary={props.item?.name} />
-        {icon}
-      </Link>
+      </ListItemButton>
     );
   } else {
     return (
-      <>
+      <ListItemButton onClick={props.onToggle}>
         <ListItemText primary={props.item?.name} />
         {icon}
-      </>
+      </ListItemButton>
     );
   }
 }
@@ -79,9 +79,7 @@ export default function SideNav(props: SideNavProps) {
             {props?.items?.map((item, index) => {
               let elem = [(
                 <ListItem key={index} disablePadding>
-                  <ListItemButton onClick={() => toggleExpand(index)}>
-                    <ListItemLink item={item} open={expandedItems.includes(index)} />
-                  </ListItemButton>
+                  <ListItemLink item={item} open={expandedItems.includes(index)} onToggle={() => toggleExpand(index)} />
                 </ListItem>
               )];
 
@@ -91,9 +89,7 @@ export default function SideNav(props: SideNavProps) {
                     <List disablePadding>
                       {item.items.map((subItem, subIndex) => (
                         <ListItem key={`${index}-${subIndex}`}>
-                          <ListItemButton>
-                            <ListItemLink item={subItem} />
-                          </ListItemButton>
+                          <ListItemLink item={subItem} />
                         </ListItem>
                       ))}
                     </List>

--- a/modules/web/src/component/SideNav/index.tsx
+++ b/modules/web/src/component/SideNav/index.tsx
@@ -40,7 +40,7 @@ function ListItemLink(props: ListItemLinkProps) {
 
   if (props.item?.link) {
     return (
-      <ListItemButton component={Link as any} href={props.item.link}>
+      <ListItemButton component={Link as React.ElementType} href={props.item.link}>
         <ListItemText primary={props.item?.name} />
       </ListItemButton>
     );


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/dashboard/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes an issue where only the text inside a navigation menu item was clickable. Now, the entire `ListItemButton` area is interactive, improving user experience.

**Which issue(s) this PR fixes**:
Fixes #61 

**Special notes for your reviewer**:
Refactored `ListItemLink` to wrap both text and icons inside `ListItemButton` while preserving its existing functionality.

https://github.com/user-attachments/assets/4528072e-655d-42b2-9e56-2857df636fe1

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Navigation menu items are now fully clickable, not just the text.
