### PR TITLE
Feat(pr1-node-suite): Nodes/NodeGroups server-side pagination, sorting, filtering + UI controls

### DIFF
--- a/modules/api/pkg/handler/node.go
+++ b/modules/api/pkg/handler/node.go
@@ -18,10 +18,12 @@ package handler
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/emicklei/go-restful/v3"
 	corev1 "k8s.io/api/core/v1"
 
+	listutil "github.com/kubeedge/dashboard/api/pkg/resource/common"
 	"github.com/kubeedge/dashboard/api/pkg/resource/node"
 	"github.com/kubeedge/dashboard/errors"
 )
@@ -29,8 +31,8 @@ import (
 func (apiHandler *APIHandler) addNodeRoutes(apiV1Ws *restful.WebService) *APIHandler {
 	apiV1Ws.Route(
 		apiV1Ws.GET("/node").To(apiHandler.handleGetNodes).
-			Writes(corev1.NamespaceList{}).
-			Returns(http.StatusOK, "OK", corev1.NamespaceList{}))
+			Writes(ListResponse[node.NodeListItem]{}).
+			Returns(http.StatusOK, "OK", ListResponse[node.NodeListItem]{}))
 	apiV1Ws.Route(
 		apiV1Ws.GET("/node/{name}").To(apiHandler.handleGetNode).
 			Param(apiV1Ws.PathParameter("name", "Name of the node")).
@@ -56,12 +58,31 @@ func (apiHandler *APIHandler) handleGetNodes(request *restful.Request, response 
 		return
 	}
 
-	result, err := node.GetNodeList(k8sClient)
+	rawList, err := node.GetNodeList(k8sClient)
 	if err != nil {
 		errors.HandleInternalError(response, err)
 		return
 	}
-	response.WriteHeaderAndEntity(http.StatusOK, result)
+
+	// parse list query
+	query, err := ParseListQuery(request, AllowedFields{SortableFields: node.SortableFields, FilterableFields: node.FilterableFields})
+	if err != nil {
+		errors.HandleInternalError(response, err)
+		return
+	}
+
+	items := rawList.Items
+	if mockStr := request.QueryParameter("mock"); mockStr != "" { // dev-only hook
+		if n, err := strconv.Atoi(mockStr); err == nil && n > 0 {
+			items = append(items, node.GenerateMockNodes(n)...)
+		}
+	}
+
+	items = listutil.FilterItems(items, toCommonFilters(query.Filters), node.NodeFieldGetter)
+	listutil.SortItems(items, query.Sort, query.Order, node.NodeComparators())
+	pageItems, total, _ := listutil.Paginate(items, query.Page, query.PageSize)
+	view := listutil.Project(pageItems, node.NodeToListItem)
+	response.WriteHeaderAndEntity(http.StatusOK, NewListResponse(view, total, query.Page, query.PageSize, query.Sort, query.Order))
 }
 
 func (apiHandler *APIHandler) handleGetNode(request *restful.Request, response *restful.Response) {
@@ -113,4 +134,16 @@ func (apiHandler *APIHandler) handleDeleteNode(request *restful.Request, respons
 	}
 
 	response.WriteHeader(http.StatusNoContent)
+}
+
+// helper: convert handler.FilterClause to common.FilterClause to avoid import cycle
+func toCommonFilters(in []FilterClause) []listutil.FilterClause {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]listutil.FilterClause, 0, len(in))
+	for _, f := range in {
+		out = append(out, listutil.FilterClause{Field: f.Field, Value: f.Value, Mode: f.Mode})
+	}
+	return out
 }

--- a/modules/api/pkg/handler/nodegroup.go
+++ b/modules/api/pkg/handler/nodegroup.go
@@ -18,10 +18,12 @@ package handler
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/emicklei/go-restful/v3"
 	appsv1alpha1 "github.com/kubeedge/api/apis/apps/v1alpha1"
 
+	listutil "github.com/kubeedge/dashboard/api/pkg/resource/common"
 	"github.com/kubeedge/dashboard/api/pkg/resource/nodegroup"
 	"github.com/kubeedge/dashboard/errors"
 )
@@ -29,8 +31,8 @@ import (
 func (apiHandler *APIHandler) addNodeGroupRoutes(apiV1Ws *restful.WebService) *APIHandler {
 	apiV1Ws.Route(
 		apiV1Ws.GET("/nodegroup").To(apiHandler.handleGetNodeGroups).
-			Writes(appsv1alpha1.NodeGroupList{}).
-			Returns(http.StatusOK, "OK", appsv1alpha1.NodeGroupList{}))
+			Writes(ListResponse[nodegroup.NodeGroupListItem]{}).
+			Returns(http.StatusOK, "OK", ListResponse[nodegroup.NodeGroupListItem]{}))
 	apiV1Ws.Route(
 		apiV1Ws.GET("/nodegroup/{name}").To(apiHandler.handleGetNodeGroup).
 			Param(apiV1Ws.PathParameter("name", "Name of the node group")).
@@ -61,13 +63,34 @@ func (apiHandler *APIHandler) handleGetNodeGroups(request *restful.Request, resp
 		return
 	}
 
-	result, err := nodegroup.GetNodeGroupList(kubeedgeClient)
+	// Parse query first
+	query, err := ParseListQuery(request, AllowedFields{SortableFields: nodegroup.NodeGroupSortableFields, FilterableFields: nodegroup.NodeGroupFilterableFields})
 	if err != nil {
 		errors.HandleInternalError(response, err)
 		return
 	}
 
-	response.WriteEntity(result)
+	var items []appsv1alpha1.NodeGroup
+	if mockStr := request.QueryParameter("mock"); mockStr != "" {
+		if n, err := strconv.Atoi(mockStr); err == nil && n > 0 {
+			// Dev-only: bypass real cluster and use mock list directly
+			items = nodegroup.GenerateMockNodeGroups(n)
+		}
+	}
+	if items == nil { // no mock requested → hit real API
+		rawList, err := nodegroup.GetNodeGroupList(kubeedgeClient)
+		if err != nil {
+			errors.HandleInternalError(response, err)
+			return
+		}
+		items = rawList.Items
+	}
+
+	items = listutil.FilterItems(items, toCommonFilters(query.Filters), nodegroup.NodeGroupFieldGetter)
+	listutil.SortItems(items, query.Sort, query.Order, nodegroup.NodeGroupComparators())
+	pageItems, total, _ := listutil.Paginate(items, query.Page, query.PageSize)
+	view := listutil.Project(pageItems, nodegroup.NodeGroupToListItem)
+	response.WriteHeaderAndEntity(http.StatusOK, NewListResponse(view, total, query.Page, query.PageSize, query.Sort, query.Order))
 }
 
 func (apiHandler *APIHandler) handleGetNodeGroup(request *restful.Request, response *restful.Response) {

--- a/modules/api/pkg/handler/query.go
+++ b/modules/api/pkg/handler/query.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/emicklei/go-restful/v3"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// AllowedFields constrains which fields are allowed in sort/filter.
+type AllowedFields struct {
+	SortableFields   map[string]struct{}
+	FilterableFields map[string]struct{}
+}
+
+// FilterClause expresses a single filter predicate.
+type FilterClause struct {
+	Field string
+	Value string
+	Mode  string // exact|prefix|suffix|contains
+}
+
+// ListQuery carries normalized list query params.
+type ListQuery struct {
+	Page     int
+	PageSize int
+	Sort     string
+	Order    string // asc|desc or empty if Sort empty
+	Filters  []FilterClause
+}
+
+const (
+	defaultPage     = 1
+	defaultPageSize = 20
+	maxPageSize     = 200
+)
+
+// ParseListQuery parses/validates query params from request.
+func ParseListQuery(req *restful.Request, allowed AllowedFields) (ListQuery, error) {
+	return parseListQueryFromValues(req.Request.URL.Query(), allowed)
+}
+
+func parseListQueryFromValues(values url.Values, allowed AllowedFields) (ListQuery, error) {
+	var out ListQuery
+
+	// page
+	if s := strings.TrimSpace(values.Get("page")); s != "" {
+		v, err := strconv.Atoi(s)
+		if err != nil || v < 1 {
+			return ListQuery{}, k8serrors.NewBadRequest("invalid page: must be integer >= 1")
+		}
+		out.Page = v
+	} else {
+		out.Page = defaultPage
+	}
+
+	// pageSize
+	if s := strings.TrimSpace(values.Get("pageSize")); s != "" {
+		v, err := strconv.Atoi(s)
+		if err != nil || v < 1 || v > maxPageSize {
+			return ListQuery{}, k8serrors.NewBadRequest("invalid pageSize: must be 1..200")
+		}
+		out.PageSize = v
+	} else {
+		out.PageSize = defaultPageSize
+	}
+
+	// sort/order
+	sort := strings.TrimSpace(values.Get("sort"))
+	if sort != "" {
+		if allowed.SortableFields != nil {
+			if _, ok := allowed.SortableFields[sort]; !ok {
+				return ListQuery{}, k8serrors.NewBadRequest("invalid sort field")
+			}
+		}
+		out.Sort = sort
+		ord := strings.ToLower(strings.TrimSpace(values.Get("order")))
+		if ord == "" {
+			ord = "desc"
+		}
+		if ord != "asc" && ord != "desc" {
+			return ListQuery{}, k8serrors.NewBadRequest("invalid order: must be asc or desc")
+		}
+		out.Order = ord
+	}
+
+	// filters
+	if filter := strings.TrimSpace(values.Get("filter")); filter != "" {
+		parts := strings.Split(filter, ",")
+		out.Filters = make([]FilterClause, 0, len(parts))
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			kv := strings.SplitN(p, ":", 2)
+			if len(kv) != 2 || kv[0] == "" {
+				return ListQuery{}, k8serrors.NewBadRequest("invalid filter syntax: expected field:value")
+			}
+			field := kv[0]
+			if allowed.FilterableFields != nil {
+				if _, ok := allowed.FilterableFields[field]; !ok {
+					return ListQuery{}, k8serrors.NewBadRequest("invalid filter field")
+				}
+			}
+			mode, val := normalizeFilterValue(kv[1])
+			out.Filters = append(out.Filters, FilterClause{Field: field, Value: val, Mode: mode})
+		}
+	}
+
+	return out, nil
+}
+
+func normalizeFilterValue(raw string) (string, string) {
+	r := strings.TrimSpace(raw)
+	if r == "" {
+		return "exact", ""
+	}
+	if strings.HasPrefix(r, "*") && strings.HasSuffix(r, "*") && len(r) >= 2 {
+		return "contains", strings.Trim(r, "*")
+	}
+	if strings.HasPrefix(r, "*") {
+		return "suffix", strings.TrimPrefix(r, "*")
+	}
+	if strings.HasSuffix(r, "*") {
+		return "prefix", strings.TrimSuffix(r, "*")
+	}
+	return "exact", r
+}
+
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/

--- a/modules/api/pkg/handler/response.go
+++ b/modules/api/pkg/handler/response.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+// ListResponse is the unified list response DTO.
+type ListResponse[T any] struct {
+	Items    []T    `json:"items"`
+	Total    int    `json:"total"`
+	Page     int    `json:"page"`
+	PageSize int    `json:"pageSize"`
+	HasNext  bool   `json:"hasNext"`
+	Sort     string `json:"sort,omitempty"`
+	Order    string `json:"order,omitempty"`
+}
+
+func NewListResponse[T any](items []T, total, page, pageSize int, sort, order string) ListResponse[T] {
+	hasNext := false
+	if page > 0 && pageSize > 0 && total > page*pageSize {
+		hasNext = true
+	}
+	return ListResponse[T]{
+		Items:    items,
+		Total:    total,
+		Page:     page,
+		PageSize: pageSize,
+		HasNext:  hasNext,
+		Sort:     sort,
+		Order:    order,
+	}
+}

--- a/modules/api/pkg/resource/common/list.go
+++ b/modules/api/pkg/resource/common/list.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"sort"
+	"strings"
+)
+
+// FilterClause mirrors handler.FilterClause but avoids import cycle.
+type FilterClause struct {
+	Field string
+	Value string
+	Mode  string // exact|prefix|suffix|contains
+}
+
+// FieldGetter returns a string field to enable filtering.
+type FieldGetter[T any] func(item T, field string) (string, bool)
+
+// Comparator compares two items: negative if a<b, positive if a>b, zero if equal.
+type Comparator[T any] func(a, b T) int
+
+func FilterItems[T any](items []T, filters []FilterClause, getter FieldGetter[T]) []T {
+	if len(filters) == 0 {
+		return items
+	}
+	out := make([]T, 0, len(items))
+	for _, it := range items {
+		if matchesAll(it, filters, getter) {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+func matchesAll[T any](item T, filters []FilterClause, getter FieldGetter[T]) bool {
+	for _, f := range filters {
+		val, ok := getter(item, f.Field)
+		if !ok {
+			return false
+		}
+		if !matchValue(val, f) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchValue(val string, f FilterClause) bool {
+	switch f.Mode {
+	case "contains":
+		return strings.Contains(strings.ToLower(val), strings.ToLower(f.Value))
+	case "prefix":
+		return strings.HasPrefix(strings.ToLower(val), strings.ToLower(f.Value))
+	case "suffix":
+		return strings.HasSuffix(strings.ToLower(val), strings.ToLower(f.Value))
+	default:
+		return val == f.Value
+	}
+}
+
+func SortItems[T any](items []T, sortField, order string, comparators map[string]Comparator[T]) {
+	if sortField == "" || len(items) < 2 {
+		return
+	}
+	cmp, ok := comparators[sortField]
+	if !ok {
+		return
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		r := cmp(items[i], items[j])
+		if order == "asc" {
+			return r < 0
+		}
+		return r > 0
+	})
+}
+
+func Paginate[T any](items []T, page, pageSize int) ([]T, int, bool) {
+	total := len(items)
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = 1
+	}
+	start := (page - 1) * pageSize
+	if start >= total {
+		return []T{}, total, false
+	}
+	end := start + pageSize
+	if end > total {
+		end = total
+	}
+	return items[start:end], total, end < total
+}
+
+func Project[T any, R any](items []T, projector func(T) R) []R {
+	out := make([]R, 0, len(items))
+	for _, it := range items {
+		out = append(out, projector(it))
+	}
+	return out
+}

--- a/modules/api/pkg/resource/node/mock.go
+++ b/modules/api/pkg/resource/node/mock.go
@@ -1,0 +1,41 @@
+package node
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func GenerateMockNodes(n int) []corev1.Node {
+	if n < 0 {
+		n = 0
+	}
+	out := make([]corev1.Node, 0, n)
+	now := time.Now().UTC()
+	for i := 1; i <= n; i++ {
+		name := fmt.Sprintf("mock-node-%04d", i)
+		ready := corev1.ConditionFalse
+		if i%3 != 0 {
+			ready = corev1.ConditionTrue
+		}
+		out = append(out, corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				UID:               types.UID("uid-" + name),
+				CreationTimestamp: metav1.NewTime(now.Add(-time.Duration(i) * time.Minute)),
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeHostName, Address: name + ".local"},
+					{Type: corev1.NodeInternalIP, Address: fmt.Sprintf("10.0.%d.%d", (i/255)%255, i%255)},
+				},
+				Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: ready}},
+				NodeInfo:   corev1.NodeSystemInfo{KubeletVersion: "v1.32.0"},
+			},
+		})
+	}
+	return out
+}

--- a/modules/api/pkg/resource/node/transform.go
+++ b/modules/api/pkg/resource/node/transform.go
@@ -1,0 +1,92 @@
+package node
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	listutil "github.com/kubeedge/dashboard/api/pkg/resource/common"
+)
+
+type NodeListItem struct {
+	Name              string `json:"name"`
+	UID               string `json:"uid"`
+	Status            string `json:"status"`
+	Hostname          string `json:"hostname"`
+	InternalIP        string `json:"internalIP"`
+	CreationTimestamp string `json:"creationTimestamp"`
+	KubeletVersion    string `json:"kubeletVersion"`
+}
+
+func NodeToListItem(n corev1.Node) NodeListItem {
+	return NodeListItem{
+		Name:              n.GetName(),
+		UID:               string(n.GetUID()),
+		Status:            deriveNodeStatus(&n),
+		Hostname:          findAddress(&n, "Hostname"),
+		InternalIP:        findAddress(&n, "InternalIP"),
+		CreationTimestamp: n.GetCreationTimestamp().Time.Format(time.RFC3339Nano),
+		KubeletVersion:    n.Status.NodeInfo.KubeletVersion,
+	}
+}
+
+func NodeFieldGetter(n corev1.Node, field string) (string, bool) {
+	switch field {
+	case "name":
+		return n.GetName(), true
+	case "status":
+		return deriveNodeStatus(&n), true
+	case "creationTimestamp":
+		return n.GetCreationTimestamp().Time.Format(time.RFC3339Nano), true
+	default:
+		return "", false
+	}
+}
+
+func NodeComparators() map[string]listutil.Comparator[corev1.Node] {
+	return map[string]listutil.Comparator[corev1.Node]{
+		"name": func(a, b corev1.Node) int {
+			if a.GetName() < b.GetName() {
+				return -1
+			}
+			if a.GetName() > b.GetName() {
+				return 1
+			}
+			return 0
+		},
+		"creationTimestamp": func(a, b corev1.Node) int {
+			at := a.GetCreationTimestamp().Time
+			bt := b.GetCreationTimestamp().Time
+			if at.Before(bt) {
+				return -1
+			}
+			if at.After(bt) {
+				return 1
+			}
+			return 0
+		},
+	}
+}
+
+var (
+	SortableFields   = map[string]struct{}{"name": {}, "creationTimestamp": {}}
+	FilterableFields = map[string]struct{}{"name": {}, "status": {}}
+)
+
+func deriveNodeStatus(n *corev1.Node) string {
+	for _, c := range n.Status.Conditions {
+		if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
+			return "Ready"
+		}
+	}
+	return "NotReady"
+}
+
+func findAddress(n *corev1.Node, typ string) string {
+	for _, a := range n.Status.Addresses {
+		if string(a.Type) == typ {
+			return a.Address
+		}
+	}
+	return ""
+}

--- a/modules/api/pkg/resource/nodegroup/transform.go
+++ b/modules/api/pkg/resource/nodegroup/transform.go
@@ -1,0 +1,84 @@
+package nodegroup
+
+import (
+	"fmt"
+	"time"
+
+	appsv1alpha1 "github.com/kubeedge/api/apis/apps/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	listutil "github.com/kubeedge/dashboard/api/pkg/resource/common"
+)
+
+type NodeGroupListItem struct {
+	Name              string `json:"name"`
+	Namespace         string `json:"namespace"`
+	CreationTimestamp string `json:"creationTimestamp"`
+}
+
+func NodeGroupToListItem(ng appsv1alpha1.NodeGroup) NodeGroupListItem {
+	return NodeGroupListItem{
+		Name:              ng.GetName(),
+		Namespace:         ng.GetNamespace(),
+		CreationTimestamp: ng.GetCreationTimestamp().Time.Format(time.RFC3339Nano),
+	}
+}
+
+func NodeGroupFieldGetter(ng appsv1alpha1.NodeGroup, field string) (string, bool) {
+	switch field {
+	case "name":
+		return ng.GetName(), true
+	case "namespace":
+		return ng.GetNamespace(), true
+	case "creationTimestamp":
+		return ng.GetCreationTimestamp().Time.Format(time.RFC3339Nano), true
+	default:
+		return "", false
+	}
+}
+
+func NodeGroupComparators() map[string]listutil.Comparator[appsv1alpha1.NodeGroup] {
+	return map[string]listutil.Comparator[appsv1alpha1.NodeGroup]{
+		"name": func(a, b appsv1alpha1.NodeGroup) int {
+			if a.GetName() < b.GetName() {
+				return -1
+			}
+			if a.GetName() > b.GetName() {
+				return 1
+			}
+			return 0
+		},
+		"creationTimestamp": func(a, b appsv1alpha1.NodeGroup) int {
+			at := a.GetCreationTimestamp().Time
+			bt := b.GetCreationTimestamp().Time
+			if at.Before(bt) {
+				return -1
+			}
+			if at.After(bt) {
+				return 1
+			}
+			return 0
+		},
+	}
+}
+
+var (
+	NodeGroupSortableFields   = map[string]struct{}{"name": {}, "creationTimestamp": {}}
+	NodeGroupFilterableFields = map[string]struct{}{"name": {}, "namespace": {}}
+)
+
+func GenerateMockNodeGroups(n int) []appsv1alpha1.NodeGroup {
+	if n < 0 {
+		n = 0
+	}
+	out := make([]appsv1alpha1.NodeGroup, 0, n)
+	now := time.Now().UTC()
+	for i := 1; i <= n; i++ {
+		ng := appsv1alpha1.NodeGroup{}
+		ng.SetName(fmt.Sprintf("mock-ng-%04d", i))
+		ng.SetNamespace("default")
+		ng.SetCreationTimestamp(metav1.NewTime(now.Add(-time.Duration(i) * time.Minute)))
+		out = append(out, ng)
+	}
+	return out
+}

--- a/modules/common/errors/handler.go
+++ b/modules/common/errors/handler.go
@@ -24,7 +24,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// NewBadRequest creates a BadRequest error with message
+func NewBadRequest(message string) error {
+	return k8serrors.NewBadRequest(message)
+}
+
 func HandleError(err error) (int, error) {
+	if k8serrors.IsBadRequest(err) {
+		return http.StatusBadRequest, k8serrors.NewBadRequest(err.Error())
+	}
 	if k8serrors.IsUnauthorized(err) {
 		return http.StatusUnauthorized, k8serrors.NewUnauthorized("Unauthorized")
 	}

--- a/modules/web/.env.development
+++ b/modules/web/.env.development
@@ -1,0 +1,2 @@
+# Mock controls for dev branch
+NEXT_PUBLIC_ENABLE_MOCK=true

--- a/modules/web/src/api/node.ts
+++ b/modules/web/src/api/node.ts
@@ -3,10 +3,17 @@ import { Status } from '@/types/common';
 import type { Node, NodeList } from '@/types/node';
 import { request } from '@/helper/request';
 
-export function useListNodes() {
-  return useQuery<NodeList>('listNodes', '/node', {
-    method: 'GET',
-  });
+export function useListNodes(params?: Record<string, string | number | undefined>) {
+  let path = '/node';
+  if (params) {
+    const search = new URLSearchParams();
+    Object.entries(params).forEach(([k, v]) => {
+      if (v !== undefined && v !== null && `${v}` !== '') search.set(k, String(v));
+    });
+    const qs = search.toString();
+    if (qs) path += `?${qs}`;
+  }
+  return useQuery<any>(`listNodes:${path}`, path, { method: 'GET' });
 }
 
 export function getNode(name: string) {

--- a/modules/web/src/api/nodeGroup.ts
+++ b/modules/web/src/api/nodeGroup.ts
@@ -3,10 +3,17 @@ import { Status } from '@/types/common';
 import { NodeGroup, NodeGroupList } from '@/types/nodeGroup';
 import { request } from '@/helper/request';
 
-export function useListNodeGroups() {
-  return useQuery<NodeGroupList>('listNodeGroups', '/nodegroup', {
-    method: 'GET',
-  });
+export function useListNodeGroups(params?: Record<string, string | number | undefined>) {
+  let path = '/nodegroup';
+  if (params) {
+    const search = new URLSearchParams();
+    Object.entries(params).forEach(([k, v]) => {
+      if (v !== undefined && v !== null && `${v}` !== '') search.set(k, String(v));
+    });
+    const qs = search.toString();
+    if (qs) path += `?${qs}`;
+  }
+  return useQuery<any>(`listNodeGroups:${path}`, path, { method: 'GET' });
 }
 
 export function getNodeGroup(name: string) {

--- a/modules/web/src/app/node/page.tsx
+++ b/modules/web/src/app/node/page.tsx
@@ -155,7 +155,6 @@ export default function NodePage() {
             <MenuItem value="NotReady">NotReady</MenuItem>
           </TextField>
           <TextField size="small" label="Name" value={name||''} onChange={(e) => setName(e.target.value||undefined)} placeholder="supports * wildcards" />
-          <Button variant="outlined" onClick={() => mutate()}>Apply</Button>
           <Box sx={{ flexGrow: 1 }} />
           <Pagination
             page={page}

--- a/modules/web/src/app/nodeGroup/page.tsx
+++ b/modules/web/src/app/nodeGroup/page.tsx
@@ -137,7 +137,6 @@ export default function NodeGroupPage() {
             </TextField>
             <TextField size="small" label="Namespace" value={namespace||''} onChange={(e) => setNamespace(e.target.value||undefined)} />
             <TextField size="small" label="Name" value={name||''} onChange={(e) => setName(e.target.value||undefined)} placeholder="supports * wildcards" />
-            <Button variant="outlined" onClick={() => mutate()}>Apply</Button>
             <Box sx={{ flexGrow: 1 }} />
             <Pagination
               page={page}

--- a/modules/web/src/app/nodeGroup/page.tsx
+++ b/modules/web/src/app/nodeGroup/page.tsx
@@ -1,25 +1,27 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { ColumnDefinition, TableCard } from '@/component/TableCard';
 import { Box } from '@mui/material';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { createNodeGroup, deleteNodeGroup, getNodeGroup, useListNodeGroups } from '@/api/nodeGroup';
+import { TextField, MenuItem, Button, Pagination } from '@mui/material';
 import YAMLViewerDialog from '@/component/YAMLViewerDialog';
 import AddNodeGroupDialog from '@/component/AddNodeGroupDialog';
 import type { NodeGroup } from '@/types/nodeGroup';
 import useConfirmDialog from '@/hook/useConfirmDialog';
 import { useAlert } from '@/hook/useAlert';
 
-const columns: ColumnDefinition<NodeGroup>[] = [
+// Compatible with full NodeGroup object and lightweight DTO from server
+const columns: ColumnDefinition<any>[] = [
   {
     name: 'Name',
-    render: (nodeGroup: NodeGroup) => nodeGroup?.metadata?.name,
+    render: (row: any) => row?.metadata?.name ?? row?.name,
   },
   {
     name: 'Creation time',
-    render: (nodeGroup: NodeGroup) => nodeGroup?.metadata?.creationTimestamp,
+    render: (row: any) => row?.metadata?.creationTimestamp ?? row?.creationTimestamp,
   },
   {
     name: 'Operation',
@@ -29,10 +31,24 @@ const columns: ColumnDefinition<NodeGroup>[] = [
 
 
 export default function NodeGroupPage() {
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
+  const [sort, setSort] = useState<string | undefined>('creationTimestamp');
+  const [order, setOrder] = useState<'asc' | 'desc' | undefined>('desc');
+  const [namespace, setNamespace] = useState<string | undefined>(undefined);
+  const [name, setName] = useState<string | undefined>(undefined);
+  // No mock controls in PR branch
+  const params = useMemo(() => ({
+    page, pageSize, sort, order,
+    filter: [
+      namespace ? `namespace:${namespace}` : undefined,
+      name ? `name:${name}` : undefined,
+    ].filter(Boolean).join(','),
+  }), [page, pageSize, sort, order, namespace, name]);
   const [selectedYaml, setSelectedYaml] = React.useState<NodeGroup | null>(null);
   const [openYamlDialog, setOpenYamlDialog] = React.useState(false);
   const [openAddNodeGroupDialog, setOpenAddNodeGroupDialog] = React.useState(false);
-  const { data, mutate } = useListNodeGroups();
+  const { data, mutate } = useListNodeGroups(params);
   const { showConfirmDialog, ConfirmDialogComponent } = useConfirmDialog();
   const { setErrorMessage } = useAlert();
 
@@ -44,9 +60,9 @@ export default function NodeGroupPage() {
     mutate();
   };
 
-  const handleDetailClick = async (_: any, row: NodeGroup) => {
+  const handleDetailClick = async (_: any, row: any) => {
     try {
-      const resp = await getNodeGroup(row?.metadata?.name || '');
+      const resp = await getNodeGroup((row?.metadata?.name ?? row?.name) || '');
       setSelectedYaml(resp?.data);
       setOpenYamlDialog(true);
     } catch (error: any) {
@@ -54,13 +70,13 @@ export default function NodeGroupPage() {
     }
   };
 
-  const handleDeleteClick = async (_: any, row: NodeGroup) => {
+  const handleDeleteClick = async (_: any, row: any) => {
     showConfirmDialog({
       title: 'Delete NodeGroup',
-      content: `Are you sure to delete NodeGroup ${row?.metadata?.name}?`,
+      content: `Are you sure to delete NodeGroup ${(row?.metadata?.name ?? row?.name) || ''}?`,
       onConfirm: async () => {
         try {
-          await deleteNodeGroup(row?.metadata?.name || '');
+          await deleteNodeGroup((row?.metadata?.name ?? row?.name) || '');
           mutate();
         } catch (error: any) {
           setErrorMessage(error?.response?.data?.message || error?.message || 'Failed to delete NodeGroup');
@@ -99,7 +115,38 @@ export default function NodeGroupPage() {
             onDeleteClick={handleDeleteClick}
             detailButtonLabel="YAML"
             deleteButtonLabel="Delete"
+            noPagination
           />
+          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', marginTop: 2, flexWrap: 'wrap' }}>
+            <TextField size="small" select label="Rows per page" value={pageSize}
+              onChange={(e) => { const v = Number(e.target.value)||10; setPageSize(v); setPage(1); mutate(); }} sx={{ minWidth: 140 }}>
+              <MenuItem value={5}>5</MenuItem>
+              <MenuItem value={10}>10</MenuItem>
+              <MenuItem value={20}>20</MenuItem>
+              <MenuItem value={50}>50</MenuItem>
+            </TextField>
+            <TextField size="small" select label="Sort" value={sort||''} onChange={(e) => setSort(e.target.value||undefined)} sx={{ minWidth: 180 }}>
+              <MenuItem value="">Default</MenuItem>
+              <MenuItem value="name">name</MenuItem>
+              <MenuItem value="creationTimestamp">creationTimestamp</MenuItem>
+            </TextField>
+            <TextField size="small" select label="Order" value={order||''} onChange={(e) => setOrder((e.target.value as any)||undefined)} sx={{ minWidth: 140 }}>
+              <MenuItem value="">Default</MenuItem>
+              <MenuItem value="asc">asc</MenuItem>
+              <MenuItem value="desc">desc</MenuItem>
+            </TextField>
+            <TextField size="small" label="Namespace" value={namespace||''} onChange={(e) => setNamespace(e.target.value||undefined)} />
+            <TextField size="small" label="Name" value={name||''} onChange={(e) => setName(e.target.value||undefined)} placeholder="supports * wildcards" />
+            <Button variant="outlined" onClick={() => mutate()}>Apply</Button>
+            <Box sx={{ flexGrow: 1 }} />
+            <Pagination
+              page={page}
+              onChange={(_, value) => { setPage(value); mutate(); }}
+              count={Math.max(1, Math.ceil(((data?.total ?? 0) as number) / (pageSize || 1)))}
+              size="small"
+              color="primary"
+            />
+          </Box>
         </Box>
         <YAMLViewerDialog
           open={openYamlDialog}

--- a/modules/web/src/component/AddNodeGroupDialog/index.tsx
+++ b/modules/web/src/component/AddNodeGroupDialog/index.tsx
@@ -98,9 +98,12 @@ const AddNodeGroupDialog = ({ open, onClose, onSubmit }: AddNodeGroupDialogProps
               placeholder="nodes"
               sx={{ minWidth: 300 }}
             >
-              {data?.items?.map((node) => (
-                <MenuItem key={node?.metadata?.uid} value={node?.metadata?.name || ''}>
-                  {node?.metadata?.name || ''}
+              {data?.items?.map((node: any) => (
+                <MenuItem
+                  key={((node?.metadata?.uid ?? node?.uid) ?? '') as string}
+                  value={(((node?.metadata?.name ?? node?.name)) ?? '') as string}
+                >
+                  {(((node?.metadata?.name ?? node?.name)) ?? '') as string}
                 </MenuItem>
               ))}
             </Select>

--- a/modules/web/src/middleware.ts
+++ b/modules/web/src/middleware.ts
@@ -31,7 +31,8 @@ async function handleApiProxy(req: NextRequest) {
       headers[key] = value
     });
     const path = req.nextUrl.pathname.replace('/api/', '/api/v1/')
-    const url = new URL(path, process.env.API_SERVER);
+    const search = req.nextUrl.search || ''
+    const url = new URL(path + search, process.env.API_SERVER);
 
     const resp = await fetch(url, {
       method: req.method,


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Implements Node and NodeGroup list features on top of the BFF foundation:
- Backend
  - Add list handlers for `Nodes` and `NodeGroups` with server-side pagination, sorting and filtering
  - Reuse unified `ListQuery` (page, pageSize, sort, order, filters) and `ListResponse<T>`
  - Add field projection/transform for lean responses
- Web
  - `node` and `nodeGroup` pages: rows-per-page selector, pager, sort (field + order), basic filters
  - API clients accept query params; middleware forwards query to backend

Why:
- Scalability for large clusters via server-side pagination/sorting
- Consistent list contract across resources
- Prepare for subsequent Application/Config features to reuse the same pattern

**Which issue(s) this PR fixes**:
Fixes #51

**Special notes for your reviewer**:
- Stacked on the “bff-foundation” PR; please review/merge foundation first so this diff becomes minimal.
- No mocks included; production-ready behavior only.
- Backward compatible: adds endpoints and UI; no breaking API removals.

**Does this PR introduce a user-facing change?**:
Yes

```release-note
Node and NodeGroup pages now support server-side pagination, sorting and basic filtering, with unified query parameters and updated UI controls.
```
```