### PR TITLE
Feat(pr5-edge-cloud-message-suite): Implement new list query, pagination, sorting, and filtering for edge-cloud message suite

### DIFF
--- a/modules/api/pkg/handler/query.go
+++ b/modules/api/pkg/handler/query.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/emicklei/go-restful/v3"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// AllowedFields constrains which fields are allowed in sort/filter.
+type AllowedFields struct {
+	SortableFields   map[string]struct{}
+	FilterableFields map[string]struct{}
+}
+
+// FilterClause expresses a single filter predicate.
+type FilterClause struct {
+	Field string
+	Value string
+	Mode  string // exact|prefix|suffix|contains
+}
+
+// ListQuery carries normalized list query params.
+type ListQuery struct {
+	Page     int
+	PageSize int
+	Sort     string
+	Order    string // asc|desc or empty if Sort empty
+	Filters  []FilterClause
+}
+
+const (
+	defaultPage     = 1
+	defaultPageSize = 20
+	maxPageSize     = 200
+)
+
+// ParseListQuery parses/validates query params from request.
+func ParseListQuery(req *restful.Request, allowed AllowedFields) (ListQuery, error) {
+	return parseListQueryFromValues(req.Request.URL.Query(), allowed)
+}
+
+func parseListQueryFromValues(values url.Values, allowed AllowedFields) (ListQuery, error) {
+	var out ListQuery
+
+	// page
+	if s := strings.TrimSpace(values.Get("page")); s != "" {
+		v, err := strconv.Atoi(s)
+		if err != nil || v < 1 {
+			return ListQuery{}, k8serrors.NewBadRequest("invalid page: must be integer >= 1")
+		}
+		out.Page = v
+	} else {
+		out.Page = defaultPage
+	}
+
+	// pageSize
+	if s := strings.TrimSpace(values.Get("pageSize")); s != "" {
+		v, err := strconv.Atoi(s)
+		if err != nil || v < 1 || v > maxPageSize {
+			return ListQuery{}, k8serrors.NewBadRequest("invalid pageSize: must be 1..200")
+		}
+		out.PageSize = v
+	} else {
+		out.PageSize = defaultPageSize
+	}
+
+	// sort/order
+	sort := strings.TrimSpace(values.Get("sort"))
+	if sort != "" {
+		if allowed.SortableFields != nil {
+			if _, ok := allowed.SortableFields[sort]; !ok {
+				return ListQuery{}, k8serrors.NewBadRequest("invalid sort field")
+			}
+		}
+		out.Sort = sort
+		ord := strings.ToLower(strings.TrimSpace(values.Get("order")))
+		if ord == "" {
+			ord = "desc"
+		}
+		if ord != "asc" && ord != "desc" {
+			return ListQuery{}, k8serrors.NewBadRequest("invalid order: must be asc or desc")
+		}
+		out.Order = ord
+	}
+
+	// filters
+	if filter := strings.TrimSpace(values.Get("filter")); filter != "" {
+		parts := strings.Split(filter, ",")
+		out.Filters = make([]FilterClause, 0, len(parts))
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			kv := strings.SplitN(p, ":", 2)
+			if len(kv) != 2 || kv[0] == "" {
+				return ListQuery{}, k8serrors.NewBadRequest("invalid filter syntax: expected field:value")
+			}
+			field := kv[0]
+			if allowed.FilterableFields != nil {
+				if _, ok := allowed.FilterableFields[field]; !ok {
+					return ListQuery{}, k8serrors.NewBadRequest("invalid filter field")
+				}
+			}
+			mode, val := normalizeFilterValue(kv[1])
+			out.Filters = append(out.Filters, FilterClause{Field: field, Value: val, Mode: mode})
+		}
+	}
+
+	return out, nil
+}
+
+func normalizeFilterValue(raw string) (string, string) {
+	r := strings.TrimSpace(raw)
+	if r == "" {
+		return "exact", ""
+	}
+	if strings.HasPrefix(r, "*") && strings.HasSuffix(r, "*") && len(r) >= 2 {
+		return "contains", strings.Trim(r, "*")
+	}
+	if strings.HasPrefix(r, "*") {
+		return "suffix", strings.TrimPrefix(r, "*")
+	}
+	if strings.HasSuffix(r, "*") {
+		return "prefix", strings.TrimSuffix(r, "*")
+	}
+	return "exact", r
+}
+
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/

--- a/modules/api/pkg/handler/response.go
+++ b/modules/api/pkg/handler/response.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+// ListResponse is the unified list response DTO.
+type ListResponse[T any] struct {
+	Items    []T    `json:"items"`
+	Total    int    `json:"total"`
+	Page     int    `json:"page"`
+	PageSize int    `json:"pageSize"`
+	HasNext  bool   `json:"hasNext"`
+	Sort     string `json:"sort,omitempty"`
+	Order    string `json:"order,omitempty"`
+}
+
+func NewListResponse[T any](items []T, total, page, pageSize int, sort, order string) ListResponse[T] {
+	hasNext := false
+	if page > 0 && pageSize > 0 && total > page*pageSize {
+		hasNext = true
+	}
+	return ListResponse[T]{
+		Items:    items,
+		Total:    total,
+		Page:     page,
+		PageSize: pageSize,
+		HasNext:  hasNext,
+		Sort:     sort,
+		Order:    order,
+	}
+}

--- a/modules/api/pkg/handler/util.go
+++ b/modules/api/pkg/handler/util.go
@@ -22,6 +22,7 @@ import (
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	k8sClient "k8s.io/client-go/kubernetes"
 
+	listutil "github.com/kubeedge/dashboard/api/pkg/resource/common"
 	"github.com/kubeedge/dashboard/client"
 	"github.com/kubeedge/dashboard/errors"
 )
@@ -63,4 +64,16 @@ func (apiHandler *APIHandler) getKubeEdgeClient(
 	}
 
 	return kubeEdgeClient, nil
+}
+
+// toCommonFilterClauses converts handler.FilterClause to common.FilterClause to avoid import cycles.
+func toCommonFilterClauses(in []FilterClause) []listutil.FilterClause {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]listutil.FilterClause, 0, len(in))
+	for _, f := range in {
+		out = append(out, listutil.FilterClause{Field: f.Field, Value: f.Value, Mode: f.Mode})
+	}
+	return out
 }

--- a/modules/api/pkg/resource/common/list.go
+++ b/modules/api/pkg/resource/common/list.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"sort"
+	"strings"
+)
+
+// FilterClause mirrors handler.FilterClause but avoids import cycle.
+type FilterClause struct {
+	Field string
+	Value string
+	Mode  string // exact|prefix|suffix|contains
+}
+
+// FieldGetter returns a string field to enable filtering.
+type FieldGetter[T any] func(item T, field string) (string, bool)
+
+// Comparator compares two items: negative if a<b, positive if a>b, zero if equal.
+type Comparator[T any] func(a, b T) int
+
+func FilterItems[T any](items []T, filters []FilterClause, getter FieldGetter[T]) []T {
+	if len(filters) == 0 {
+		return items
+	}
+	out := make([]T, 0, len(items))
+	for _, it := range items {
+		if matchesAll(it, filters, getter) {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+func matchesAll[T any](item T, filters []FilterClause, getter FieldGetter[T]) bool {
+	for _, f := range filters {
+		val, ok := getter(item, f.Field)
+		if !ok {
+			return false
+		}
+		if !matchValue(val, f) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchValue(val string, f FilterClause) bool {
+	switch f.Mode {
+	case "contains":
+		return strings.Contains(strings.ToLower(val), strings.ToLower(f.Value))
+	case "prefix":
+		return strings.HasPrefix(strings.ToLower(val), strings.ToLower(f.Value))
+	case "suffix":
+		return strings.HasSuffix(strings.ToLower(val), strings.ToLower(f.Value))
+	default:
+		return val == f.Value
+	}
+}
+
+func SortItems[T any](items []T, sortField, order string, comparators map[string]Comparator[T]) {
+	if sortField == "" || len(items) < 2 {
+		return
+	}
+	cmp, ok := comparators[sortField]
+	if !ok {
+		return
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		r := cmp(items[i], items[j])
+		if order == "asc" {
+			return r < 0
+		}
+		return r > 0
+	})
+}
+
+func Paginate[T any](items []T, page, pageSize int) ([]T, int, bool) {
+	total := len(items)
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = 1
+	}
+	start := (page - 1) * pageSize
+	if start >= total {
+		return []T{}, total, false
+	}
+	end := start + pageSize
+	if end > total {
+		end = total
+	}
+	return items[start:end], total, end < total
+}
+
+func Project[T any, R any](items []T, projector func(T) R) []R {
+	out := make([]R, 0, len(items))
+	for _, it := range items {
+		out = append(out, projector(it))
+	}
+	return out
+}

--- a/modules/api/pkg/resource/rule/transform.go
+++ b/modules/api/pkg/resource/rule/transform.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	rulev1 "github.com/kubeedge/api/apis/rules/v1"
+
+	"github.com/kubeedge/dashboard/api/pkg/resource/common"
+)
+
+// RuleListItem represents a simplified Rule for list responses
+type RuleListItem struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	Source            string            `json:"source"`
+	SourceResource    string            `json:"sourceResource"`
+	Target            string            `json:"target"`
+	TargetResource    string            `json:"targetResource"`
+	CreationTimestamp time.Time         `json:"creationTimestamp"`
+	Labels            map[string]string `json:"labels,omitempty"`
+}
+
+// RuleToListItem converts a Rule to RuleListItem
+func RuleToListItem(r rulev1.Rule) RuleListItem {
+	// Simplified implementation - using available fields
+	var sourceResource, targetResource string
+	if len(r.Spec.SourceResource) > 0 {
+		sourceResource = fmt.Sprintf("%v", r.Spec.SourceResource)
+	}
+	if len(r.Spec.TargetResource) > 0 {
+		targetResource = fmt.Sprintf("%v", r.Spec.TargetResource)
+	}
+
+	return RuleListItem{
+		Name:              r.ObjectMeta.Name,
+		Namespace:         r.ObjectMeta.Namespace,
+		Source:            r.Spec.Source,
+		SourceResource:    sourceResource,
+		Target:            r.Spec.Target,
+		TargetResource:    targetResource,
+		CreationTimestamp: r.ObjectMeta.CreationTimestamp.Time,
+		Labels:            r.ObjectMeta.Labels,
+	}
+}
+
+// RuleFieldGetter returns field values for filtering
+func RuleFieldGetter(r rulev1.Rule, field string) (string, bool) {
+	switch field {
+	case "name":
+		return r.ObjectMeta.Name, true
+	case "namespace":
+		return r.ObjectMeta.Namespace, true
+	case "source":
+		return r.Spec.Source, true
+	case "target":
+		return r.Spec.Target, true
+	case "sourceResource":
+		return fmt.Sprintf("%v", r.Spec.SourceResource), true
+	case "targetResource":
+		return fmt.Sprintf("%v", r.Spec.TargetResource), true
+	case "creationTimestamp":
+		return r.ObjectMeta.CreationTimestamp.Format(time.RFC3339), true
+	default:
+		return "", false
+	}
+}
+
+// RuleComparators returns comparison functions for sorting
+func RuleComparators() map[string]common.Comparator[rulev1.Rule] {
+	return map[string]common.Comparator[rulev1.Rule]{
+		"name": func(a, b rulev1.Rule) int {
+			return strings.Compare(a.ObjectMeta.Name, b.ObjectMeta.Name)
+		},
+		"namespace": func(a, b rulev1.Rule) int {
+			return strings.Compare(a.ObjectMeta.Namespace, b.ObjectMeta.Namespace)
+		},
+		"source": func(a, b rulev1.Rule) int {
+			return strings.Compare(a.Spec.Source, b.Spec.Source)
+		},
+		"target": func(a, b rulev1.Rule) int {
+			return strings.Compare(a.Spec.Target, b.Spec.Target)
+		},
+		"creationTimestamp": func(a, b rulev1.Rule) int {
+			return a.ObjectMeta.CreationTimestamp.Time.Compare(b.ObjectMeta.CreationTimestamp.Time)
+		},
+	}
+}
+
+// SortableFields defines which fields can be used for sorting
+var SortableFields = map[string]struct{}{
+	"name":              {},
+	"namespace":         {},
+	"source":            {},
+	"target":            {},
+	"creationTimestamp": {},
+}
+
+// FilterableFields defines which fields can be used for filtering
+var FilterableFields = map[string]struct{}{
+	"name":           {},
+	"namespace":      {},
+	"source":         {},
+	"target":         {},
+	"sourceResource": {},
+	"targetResource": {},
+}

--- a/modules/api/pkg/resource/ruleendpoint/transform.go
+++ b/modules/api/pkg/resource/ruleendpoint/transform.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ruleendpoint
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	rulev1 "github.com/kubeedge/api/apis/rules/v1"
+
+	"github.com/kubeedge/dashboard/api/pkg/resource/common"
+)
+
+// RuleEndpointListItem represents a simplified RuleEndpoint for list responses
+type RuleEndpointListItem struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	RuleEndpointType  string            `json:"ruleEndpointType"`
+	Properties        map[string]string `json:"properties,omitempty"`
+	CreationTimestamp time.Time         `json:"creationTimestamp"`
+	Labels            map[string]string `json:"labels,omitempty"`
+}
+
+// RuleEndpointToListItem converts a RuleEndpoint to RuleEndpointListItem
+func RuleEndpointToListItem(re rulev1.RuleEndpoint) RuleEndpointListItem {
+	var ruleEndpointType string
+	var properties map[string]string
+
+	if re.Spec.RuleEndpointType != "" {
+		ruleEndpointType = string(re.Spec.RuleEndpointType)
+	}
+
+	// Extract key properties for display
+	properties = make(map[string]string)
+	if re.Spec.Properties != nil {
+		// Convert properties to string map for display
+		for k, v := range re.Spec.Properties {
+			properties[k] = fmt.Sprintf("%v", v)
+		}
+	}
+
+	return RuleEndpointListItem{
+		Name:              re.ObjectMeta.Name,
+		Namespace:         re.ObjectMeta.Namespace,
+		RuleEndpointType:  ruleEndpointType,
+		Properties:        properties,
+		CreationTimestamp: re.ObjectMeta.CreationTimestamp.Time,
+		Labels:            re.ObjectMeta.Labels,
+	}
+}
+
+// RuleEndpointFieldGetter returns field values for filtering
+func RuleEndpointFieldGetter(re rulev1.RuleEndpoint, field string) (string, bool) {
+	switch field {
+	case "name":
+		return re.ObjectMeta.Name, true
+	case "namespace":
+		return re.ObjectMeta.Namespace, true
+	case "ruleEndpointType":
+		return string(re.Spec.RuleEndpointType), true
+	case "creationTimestamp":
+		return re.ObjectMeta.CreationTimestamp.Format(time.RFC3339), true
+	default:
+		return "", false
+	}
+}
+
+// RuleEndpointComparators returns comparison functions for sorting
+func RuleEndpointComparators() map[string]common.Comparator[rulev1.RuleEndpoint] {
+	return map[string]common.Comparator[rulev1.RuleEndpoint]{
+		"name": func(a, b rulev1.RuleEndpoint) int {
+			return strings.Compare(a.ObjectMeta.Name, b.ObjectMeta.Name)
+		},
+		"namespace": func(a, b rulev1.RuleEndpoint) int {
+			return strings.Compare(a.ObjectMeta.Namespace, b.ObjectMeta.Namespace)
+		},
+		"ruleEndpointType": func(a, b rulev1.RuleEndpoint) int {
+			return strings.Compare(string(a.Spec.RuleEndpointType), string(b.Spec.RuleEndpointType))
+		},
+		"creationTimestamp": func(a, b rulev1.RuleEndpoint) int {
+			return a.ObjectMeta.CreationTimestamp.Time.Compare(b.ObjectMeta.CreationTimestamp.Time)
+		},
+	}
+}
+
+// SortableFields defines which fields can be used for sorting
+var SortableFields = map[string]struct{}{
+	"name":              {},
+	"namespace":         {},
+	"ruleEndpointType":  {},
+	"creationTimestamp": {},
+}
+
+// FilterableFields defines which fields can be used for filtering
+var FilterableFields = map[string]struct{}{
+	"name":             {},
+	"namespace":        {},
+	"ruleEndpointType": {},
+}

--- a/modules/common/errors/handler.go
+++ b/modules/common/errors/handler.go
@@ -24,7 +24,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// NewBadRequest creates a BadRequest error with message
+func NewBadRequest(message string) error {
+	return k8serrors.NewBadRequest(message)
+}
+
 func HandleError(err error) (int, error) {
+	if k8serrors.IsBadRequest(err) {
+		return http.StatusBadRequest, k8serrors.NewBadRequest(err.Error())
+	}
 	if k8serrors.IsUnauthorized(err) {
 		return http.StatusUnauthorized, k8serrors.NewUnauthorized("Unauthorized")
 	}

--- a/modules/web/src/api/rule.ts
+++ b/modules/web/src/api/rule.ts
@@ -3,8 +3,21 @@ import { Status } from '@/types/common';
 import { Rule, RuleList } from '@/types/rule';
 import { request } from '@/helper/request';
 
-export function useListRules(namespace?: string) {
-  const url = namespace ? `/rule/${namespace}` : '/rule';
+export function useListRules(params?: Record<string, string | number | undefined>) {
+  const searchParams = new URLSearchParams();
+  
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== '' && key !== 'namespace') {
+        searchParams.append(key, value.toString());
+      }
+    });
+  }
+  
+  const namespace = params?.namespace as string;
+  const baseUrl = namespace ? `/rule/${namespace}` : '/rule';
+  const url = searchParams.toString() ? `${baseUrl}?${searchParams.toString()}` : baseUrl;
+  
   return useQuery<RuleList>('listRules', url, {
     method: 'GET',
   });

--- a/modules/web/src/api/ruleEndpoint.ts
+++ b/modules/web/src/api/ruleEndpoint.ts
@@ -3,8 +3,21 @@ import { Status } from '@/types/common';
 import { RuleEndpoint, RuleEndpointList } from '@/types/ruleEndpoint';
 import { request } from '@/helper/request';
 
-export function useListRuleEndpoints(namespace?: string) {
-  const url = namespace ? `/ruleendpoint/${namespace}` : '/ruleendpoint';
+export function useListRuleEndpoints(params?: Record<string, string | number | undefined>) {
+  const searchParams = new URLSearchParams();
+  
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== '' && key !== 'namespace') {
+        searchParams.append(key, value.toString());
+      }
+    });
+  }
+  
+  const namespace = params?.namespace as string;
+  const baseUrl = namespace ? `/ruleendpoint/${namespace}` : '/ruleendpoint';
+  const url = searchParams.toString() ? `${baseUrl}?${searchParams.toString()}` : baseUrl;
+  
   return useQuery<RuleEndpointList>('listRuleEndpoints', url, {
     method: 'GET',
   });

--- a/modules/web/src/app/rule/page.tsx
+++ b/modules/web/src/app/rule/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { ColumnDefinition, TableCard } from '@/component/TableCard';
-import { Box } from '@mui/material';
+import { Box, TextField, MenuItem, Pagination } from '@mui/material';
 import { createRule, deleteRule, getRule, useListRules } from '@/api/rule';
 import AddRuleDialog from '@/component/AddRuleDialog';
 import YAMLViewerDialog from '@/component/YAMLViewerDialog';
@@ -11,34 +11,34 @@ import { useNamespace } from '@/hook/useNamespace';
 import useConfirmDialog from '@/hook/useConfirmDialog';
 import { useAlert } from '@/hook/useAlert';
 
-const columns: ColumnDefinition<Rule>[] = [
+const columns: ColumnDefinition<Rule | any>[] = [
   {
     name: 'Namespace',
-    render: (rule) => rule?.metadata?.namespace,
+    render: (rule) => rule?.metadata?.namespace || rule?.namespace,
   },
   {
     name: 'Name',
-    render: (rule) => rule?.metadata?.name,
+    render: (rule) => rule?.metadata?.name || rule?.name,
   },
   {
     name: 'Source',
-    render: (rule) => rule?.spec?.source,
+    render: (rule) => rule?.spec?.source || rule?.source,
   },
   {
     name: 'SourceResource',
-    render: (rule) => rule?.spec?.sourceResource?.path,
+    render: (rule) => rule?.spec?.sourceResource?.path || rule?.sourceResource,
   },
   {
     name: 'Target',
-    render: (rule) => rule?.spec?.target,
+    render: (rule) => rule?.spec?.target || rule?.target,
   },
   {
     name: 'TargetResource',
-    render: (rule) => rule?.spec?.targetResource?.path,
+    render: (rule) => rule?.spec?.targetResource?.path || rule?.targetResource,
   },
   {
     name: 'Creation time',
-    render: (rule) => rule.metadata?.creationTimestamp,
+    render: (rule) => rule.metadata?.creationTimestamp || rule?.creationTimestamp,
   },
   {
     name: 'Operation',
@@ -51,13 +51,31 @@ export default function RulePage() {
   const [yamlDialogOpen, setYamlDialogOpen] = React.useState(false);
   const [currentYamlContent, setCurrentYamlContent] = React.useState<any>(null);
   const { namespace } = useNamespace();
-  const { data, mutate } = useListRules(namespace);
   const { showConfirmDialog, ConfirmDialogComponent } = useConfirmDialog();
   const { setErrorMessage } = useAlert();
 
+  // New pagination state
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [sort, setSort] = useState('name');
+  const [order, setOrder] = useState('asc');
+  const [name, setName] = useState('');
+
+
+  const params = useMemo(() => ({
+    namespace,
+    page,
+    pageSize,
+    sort,
+    order,
+    name: name ? `*${name}*` : undefined,
+  }), [namespace, page, pageSize, sort, order, name]);
+
+  const { data, mutate } = useListRules(params);
+
   useEffect(() => {
     mutate();
-  }, [namespace, mutate]);
+  }, [params, mutate]);
 
   const handleAddClick = () => {
     setAddDialogOpen(true);
@@ -126,7 +144,73 @@ export default function RulePage() {
           onDeleteClick={handleDeleteClick}
           detailButtonLabel="YAML"
           deleteButtonLabel="Delete"
+          noPagination={true}
         />
+
+        {/* New pagination controls */}
+        <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', mt: 2, flexWrap: 'wrap' }}>
+          <TextField
+            select
+            size="small"
+            label="Rows per page"
+            value={pageSize}
+            onChange={(e) => {
+              setPageSize(Number(e.target.value));
+              setPage(1);
+            }}
+            sx={{ minWidth: 120 }}
+          >
+            <MenuItem value={5}>5</MenuItem>
+            <MenuItem value={10}>10</MenuItem>
+            <MenuItem value={20}>20</MenuItem>
+            <MenuItem value={50}>50</MenuItem>
+          </TextField>
+
+          <TextField
+            select
+            size="small"
+            label="Sort"
+            value={sort}
+            onChange={(e) => setSort(e.target.value)}
+            sx={{ minWidth: 120 }}
+          >
+            <MenuItem value="name">Name</MenuItem>
+            <MenuItem value="source">Source</MenuItem>
+            <MenuItem value="target">Target</MenuItem>
+            <MenuItem value="creationTimestamp">Creation Time</MenuItem>
+          </TextField>
+
+          <TextField
+            select
+            size="small"
+            label="Order"
+            value={order}
+            onChange={(e) => setOrder(e.target.value)}
+            sx={{ minWidth: 100 }}
+          >
+            <MenuItem value="asc">Ascending</MenuItem>
+            <MenuItem value="desc">Descending</MenuItem>
+          </TextField>
+
+          <TextField
+            size="small"
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Filter by name..."
+            sx={{ minWidth: 200 }}
+          />
+
+
+
+          <Pagination
+            count={data?.total ? Math.ceil(data.total / pageSize) : 1}
+            page={page}
+            onChange={(_, newPage) => setPage(newPage)}
+            color="primary"
+            sx={{ ml: 'auto' }}
+          />
+        </Box>
       </Box>
       <AddRuleDialog
         open={addDialogOpen}

--- a/modules/web/src/middleware.ts
+++ b/modules/web/src/middleware.ts
@@ -31,7 +31,8 @@ async function handleApiProxy(req: NextRequest) {
       headers[key] = value
     });
     const path = req.nextUrl.pathname.replace('/api/', '/api/v1/')
-    const url = new URL(path, process.env.API_SERVER);
+    const search = req.nextUrl.search || ''
+    const url = new URL(path + search, process.env.API_SERVER);
 
     const resp = await fetch(url, {
       method: req.method,

--- a/modules/web/src/types/rule.d.ts
+++ b/modules/web/src/types/rule.d.ts
@@ -19,4 +19,11 @@ export interface Rule extends TypeMeta {
   status?: RuleStatus;
 }
 
-export interface RuleList extends ResourceList<Rule> {}
+export interface RuleList extends ResourceList<Rule> {
+  total?: number;
+  page?: number;
+  pageSize?: number;
+  hasNext?: boolean;
+  sort?: string;
+  order?: string;
+}

--- a/modules/web/src/types/ruleEndpoint.d.ts
+++ b/modules/web/src/types/ruleEndpoint.d.ts
@@ -10,4 +10,11 @@ export interface RuleEndpoint extends TypeMeta {
   spec?: RuleEndpointSpec;
 }
 
-export interface RuleEndpointList extends ResourceList<RuleEndpoint> {}
+export interface RuleEndpointList extends ResourceList<RuleEndpoint> {
+  total?: number;
+  page?: number;
+  pageSize?: number;
+  hasNext?: boolean;
+  sort?: string;
+  order?: string;
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/dashboard/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind feature
/kind api-change

**What this PR does / why we need it**:

This PR implements the new unified list query, pagination, sorting, and filtering system for the Edge-Cloud Message suite (Rules and RuleEndpoints), completing the edge-cloud messaging functionality following the same architectural pattern established in foundation/PR1/PR2/PR3/PR4.

**Backend Changes:**
- Add unified `ListQuery` parameter parsing for Rule and RuleEndpoint handlers
- Implement `ListResponse` with pagination metadata (total, page, pageSize, hasNext)
- Create resource-specific transform logic in `transform.go` files:
  - `RuleListItem` DTO with projection, field getters, and comparators
  - `RuleEndpointListItem` DTO with projection, field getters, and comparators
- Support server-side filtering, sorting, and pagination using `common` functions
- Add proper error handling for unavailable KubeEdge resources (returns empty list instead of 500 error)

**Frontend Changes:**
- Replace old TableCard pagination with new unified pagination controls
- Add state management for page, pageSize, sort, order, and filter parameters
- Implement new MUI-based pagination UI with dropdowns and navigation
- Update API hooks to accept query parameters object instead of single namespace
- Update column definitions to handle both original and transformed data types
- Update TypeScript types to match new ListResponse format

**Key Features:**
- Consistent pagination UI across Rules and RuleEndpoints
- Server-side filtering with wildcard support (`name:*pattern*`)
- Configurable page sizes (5, 10, 20, 50)
- Sortable by name, ruleEndpointType, source/target, and creationTimestamp
- Ascending/descending order support
- Optimized frontend-backend communication (only sends necessary fields via DTOs)
- Graceful degradation when KubeEdge edge-cloud message resources are not available

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

This PR completes the edge-cloud message suite (Rules + RuleEndpoints) following the established architectural pattern from foundation/PR1/PR2/PR3/PR4. All five PRs (node-suite, application-suite, config-suite, device-suite, edge-cloud-message-suite) can be merged without conflicts as verified by merge simulation in the `test-merge-simulation` branch.

The implementation includes:
1. **Unified architecture**: Consistent with other PR branches using BFF pattern
2. **Error resilience**: Handles cases where KubeEdge Rules/RuleEndpoints CRDs are not installed
3. **Type safety**: Full TypeScript support with proper interface definitions
4. **Performance optimization**: Server-side pagination reduces data transfer
5. **User experience**: Consistent UI/UX across all resource types

The edge-cloud messaging functionality enables users to manage message routing rules and endpoints in KubeEdge environments with the same modern pagination, sorting, and filtering capabilities available for other resource types.

**Does this PR introduce a user-facing change?**:

```release-note
Rules and RuleEndpoints pages now feature improved pagination, sorting, and filtering controls. Users can now:
- Configure page size (5/10/20/50 items per page)
- Sort by name, rule endpoint type, source/target, or creation timestamp in ascending/descending order
- Filter rules and rule endpoints by name with wildcard support
- Navigate through pages with improved pagination controls
- Experience faster loading with optimized data transfer
- View real KubeEdge edge-cloud message data with consistent UI across all resource types
- Continue using the interface even when KubeEdge Rules/RuleEndpoints CRDs are not available (shows empty state)
```