### PR TITLE
docs: add CMU email as co-author to BFF proposal

### DIFF
--- a/docs/proposals/51-optimize-data-processing/README.md
+++ b/docs/proposals/51-optimize-data-processing/README.md
@@ -3,6 +3,7 @@ title: Dashboard Data Processing Optimization via BFF Layer
 status: implementable
 authors:
   - "@ellie604"
+  - "@xinyilu2@andrew.cmu.edu"
 approvers:
   - "@ghosind"
   - "@Shelley-BaoYue"


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:

This PR adds the CMU email address (@xinyilu2@andrew.cmu.edu) as a co-author to the BFF proposal, ensuring proper attribution for academic and professional records.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This is a documentation update to add the CMU email as a co-author alongside the existing GitHub handle. No functional changes.

**Does this PR introduce a user-facing change?**:
NONE