### PR TITLE
Feat(pr3-config-suite): Implement new list query, pagination, sorting…

### DIFF
--- a/modules/api/pkg/handler/query.go
+++ b/modules/api/pkg/handler/query.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/emicklei/go-restful/v3"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// AllowedFields constrains which fields are allowed in sort/filter.
+type AllowedFields struct {
+	SortableFields   map[string]struct{}
+	FilterableFields map[string]struct{}
+}
+
+// FilterClause expresses a single filter predicate.
+type FilterClause struct {
+	Field string
+	Value string
+	Mode  string // exact|prefix|suffix|contains
+}
+
+// ListQuery carries normalized list query params.
+type ListQuery struct {
+	Page     int
+	PageSize int
+	Sort     string
+	Order    string // asc|desc or empty if Sort empty
+	Filters  []FilterClause
+}
+
+const (
+	defaultPage     = 1
+	defaultPageSize = 20
+	maxPageSize     = 200
+)
+
+// ParseListQuery parses/validates query params from request.
+func ParseListQuery(req *restful.Request, allowed AllowedFields) (ListQuery, error) {
+	return parseListQueryFromValues(req.Request.URL.Query(), allowed)
+}
+
+func parseListQueryFromValues(values url.Values, allowed AllowedFields) (ListQuery, error) {
+	var out ListQuery
+
+	// page
+	if s := strings.TrimSpace(values.Get("page")); s != "" {
+		v, err := strconv.Atoi(s)
+		if err != nil || v < 1 {
+			return ListQuery{}, k8serrors.NewBadRequest("invalid page: must be integer >= 1")
+		}
+		out.Page = v
+	} else {
+		out.Page = defaultPage
+	}
+
+	// pageSize
+	if s := strings.TrimSpace(values.Get("pageSize")); s != "" {
+		v, err := strconv.Atoi(s)
+		if err != nil || v < 1 || v > maxPageSize {
+			return ListQuery{}, k8serrors.NewBadRequest("invalid pageSize: must be 1..200")
+		}
+		out.PageSize = v
+	} else {
+		out.PageSize = defaultPageSize
+	}
+
+	// sort/order
+	sort := strings.TrimSpace(values.Get("sort"))
+	if sort != "" {
+		if allowed.SortableFields != nil {
+			if _, ok := allowed.SortableFields[sort]; !ok {
+				return ListQuery{}, k8serrors.NewBadRequest("invalid sort field")
+			}
+		}
+		out.Sort = sort
+		ord := strings.ToLower(strings.TrimSpace(values.Get("order")))
+		if ord == "" {
+			ord = "desc"
+		}
+		if ord != "asc" && ord != "desc" {
+			return ListQuery{}, k8serrors.NewBadRequest("invalid order: must be asc or desc")
+		}
+		out.Order = ord
+	}
+
+	// filters
+	if filter := strings.TrimSpace(values.Get("filter")); filter != "" {
+		parts := strings.Split(filter, ",")
+		out.Filters = make([]FilterClause, 0, len(parts))
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			kv := strings.SplitN(p, ":", 2)
+			if len(kv) != 2 || kv[0] == "" {
+				return ListQuery{}, k8serrors.NewBadRequest("invalid filter syntax: expected field:value")
+			}
+			field := kv[0]
+			if allowed.FilterableFields != nil {
+				if _, ok := allowed.FilterableFields[field]; !ok {
+					return ListQuery{}, k8serrors.NewBadRequest("invalid filter field")
+				}
+			}
+			mode, val := normalizeFilterValue(kv[1])
+			out.Filters = append(out.Filters, FilterClause{Field: field, Value: val, Mode: mode})
+		}
+	}
+
+	return out, nil
+}
+
+func normalizeFilterValue(raw string) (string, string) {
+	r := strings.TrimSpace(raw)
+	if r == "" {
+		return "exact", ""
+	}
+	if strings.HasPrefix(r, "*") && strings.HasSuffix(r, "*") && len(r) >= 2 {
+		return "contains", strings.Trim(r, "*")
+	}
+	if strings.HasPrefix(r, "*") {
+		return "suffix", strings.TrimPrefix(r, "*")
+	}
+	if strings.HasSuffix(r, "*") {
+		return "prefix", strings.TrimSuffix(r, "*")
+	}
+	return "exact", r
+}
+
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/

--- a/modules/api/pkg/handler/response.go
+++ b/modules/api/pkg/handler/response.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+// ListResponse is the unified list response DTO.
+type ListResponse[T any] struct {
+	Items    []T    `json:"items"`
+	Total    int    `json:"total"`
+	Page     int    `json:"page"`
+	PageSize int    `json:"pageSize"`
+	HasNext  bool   `json:"hasNext"`
+	Sort     string `json:"sort,omitempty"`
+	Order    string `json:"order,omitempty"`
+}
+
+func NewListResponse[T any](items []T, total, page, pageSize int, sort, order string) ListResponse[T] {
+	hasNext := false
+	if page > 0 && pageSize > 0 && total > page*pageSize {
+		hasNext = true
+	}
+	return ListResponse[T]{
+		Items:    items,
+		Total:    total,
+		Page:     page,
+		PageSize: pageSize,
+		HasNext:  hasNext,
+		Sort:     sort,
+		Order:    order,
+	}
+}

--- a/modules/api/pkg/handler/util.go
+++ b/modules/api/pkg/handler/util.go
@@ -22,6 +22,7 @@ import (
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	k8sClient "k8s.io/client-go/kubernetes"
 
+	listutil "github.com/kubeedge/dashboard/api/pkg/resource/common"
 	"github.com/kubeedge/dashboard/client"
 	"github.com/kubeedge/dashboard/errors"
 )
@@ -63,4 +64,16 @@ func (apiHandler *APIHandler) getKubeEdgeClient(
 	}
 
 	return kubeEdgeClient, nil
+}
+
+// toCommonFilterClauses converts handler.FilterClause to common.FilterClause to avoid import cycles.
+func toCommonFilterClauses(in []FilterClause) []listutil.FilterClause {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]listutil.FilterClause, 0, len(in))
+	for _, f := range in {
+		out = append(out, listutil.FilterClause{Field: f.Field, Value: f.Value, Mode: f.Mode})
+	}
+	return out
 }

--- a/modules/api/pkg/resource/common/list.go
+++ b/modules/api/pkg/resource/common/list.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"sort"
+	"strings"
+)
+
+// FilterClause mirrors handler.FilterClause but avoids import cycle.
+type FilterClause struct {
+	Field string
+	Value string
+	Mode  string // exact|prefix|suffix|contains
+}
+
+// FieldGetter returns a string field to enable filtering.
+type FieldGetter[T any] func(item T, field string) (string, bool)
+
+// Comparator compares two items: negative if a<b, positive if a>b, zero if equal.
+type Comparator[T any] func(a, b T) int
+
+func FilterItems[T any](items []T, filters []FilterClause, getter FieldGetter[T]) []T {
+	if len(filters) == 0 {
+		return items
+	}
+	out := make([]T, 0, len(items))
+	for _, it := range items {
+		if matchesAll(it, filters, getter) {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+func matchesAll[T any](item T, filters []FilterClause, getter FieldGetter[T]) bool {
+	for _, f := range filters {
+		val, ok := getter(item, f.Field)
+		if !ok {
+			return false
+		}
+		if !matchValue(val, f) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchValue(val string, f FilterClause) bool {
+	switch f.Mode {
+	case "contains":
+		return strings.Contains(strings.ToLower(val), strings.ToLower(f.Value))
+	case "prefix":
+		return strings.HasPrefix(strings.ToLower(val), strings.ToLower(f.Value))
+	case "suffix":
+		return strings.HasSuffix(strings.ToLower(val), strings.ToLower(f.Value))
+	default:
+		return val == f.Value
+	}
+}
+
+func SortItems[T any](items []T, sortField, order string, comparators map[string]Comparator[T]) {
+	if sortField == "" || len(items) < 2 {
+		return
+	}
+	cmp, ok := comparators[sortField]
+	if !ok {
+		return
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		r := cmp(items[i], items[j])
+		if order == "asc" {
+			return r < 0
+		}
+		return r > 0
+	})
+}
+
+func Paginate[T any](items []T, page, pageSize int) ([]T, int, bool) {
+	total := len(items)
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = 1
+	}
+	start := (page - 1) * pageSize
+	if start >= total {
+		return []T{}, total, false
+	}
+	end := start + pageSize
+	if end > total {
+		end = total
+	}
+	return items[start:end], total, end < total
+}
+
+func Project[T any, R any](items []T, projector func(T) R) []R {
+	out := make([]R, 0, len(items))
+	for _, it := range items {
+		out = append(out, projector(it))
+	}
+	return out
+}

--- a/modules/api/pkg/resource/configmap/transform.go
+++ b/modules/api/pkg/resource/configmap/transform.go
@@ -1,0 +1,89 @@
+package configmap
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	listutil "github.com/kubeedge/dashboard/api/pkg/resource/common"
+)
+
+// ConfigMapListItem is the lightweight view returned by list API.
+type ConfigMapListItem struct {
+	Name              string `json:"name"`
+	Namespace         string `json:"namespace"`
+	CreationTimestamp string `json:"creationTimestamp"`
+}
+
+func ConfigMapToListItem(cm corev1.ConfigMap) ConfigMapListItem {
+	return ConfigMapListItem{
+		Name:              cm.GetName(),
+		Namespace:         cm.GetNamespace(),
+		CreationTimestamp: cm.GetCreationTimestamp().Time.Format(time.RFC3339Nano),
+	}
+}
+
+func ConfigMapFieldGetter(cm corev1.ConfigMap, field string) (string, bool) {
+	switch field {
+	case "name":
+		return cm.GetName(), true
+	case "namespace":
+		return cm.GetNamespace(), true
+	case "creationTimestamp":
+		return cm.GetCreationTimestamp().Time.Format(time.RFC3339Nano), true
+	default:
+		return "", false
+	}
+}
+
+func ConfigMapComparators() map[string]listutil.Comparator[corev1.ConfigMap] {
+	return map[string]listutil.Comparator[corev1.ConfigMap]{
+		"name": func(a, b corev1.ConfigMap) int {
+			if a.GetName() < b.GetName() {
+				return -1
+			}
+			if a.GetName() > b.GetName() {
+				return 1
+			}
+			return 0
+		},
+		"creationTimestamp": func(a, b corev1.ConfigMap) int {
+			at := a.GetCreationTimestamp().Time
+			bt := b.GetCreationTimestamp().Time
+			if at.Before(bt) {
+				return -1
+			}
+			if at.After(bt) {
+				return 1
+			}
+			return 0
+		},
+	}
+}
+
+var (
+	SortableFields   = map[string]struct{}{"name": {}, "creationTimestamp": {}}
+	FilterableFields = map[string]struct{}{"name": {}, "namespace": {}}
+)
+
+// GenerateMockConfigMaps creates mock resources for dev/testing.
+func GenerateMockConfigMaps(n int, namespace string) []corev1.ConfigMap {
+	if n < 0 {
+		n = 0
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+	out := make([]corev1.ConfigMap, 0, n)
+	now := time.Now().UTC()
+	for i := 1; i <= n; i++ {
+		cm := corev1.ConfigMap{}
+		cm.SetName(fmt.Sprintf("mock-cm-%04d", i))
+		cm.SetNamespace(namespace)
+		cm.SetCreationTimestamp(metav1.NewTime(now.Add(-time.Duration(i) * time.Minute)))
+		out = append(out, cm)
+	}
+	return out
+}

--- a/modules/api/pkg/resource/secret/transform.go
+++ b/modules/api/pkg/resource/secret/transform.go
@@ -1,0 +1,93 @@
+package secret
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	listutil "github.com/kubeedge/dashboard/api/pkg/resource/common"
+)
+
+type SecretListItem struct {
+	Name              string `json:"name"`
+	Namespace         string `json:"namespace"`
+	Type              string `json:"type"`
+	CreationTimestamp string `json:"creationTimestamp"`
+}
+
+func SecretToListItem(s corev1.Secret) SecretListItem {
+	return SecretListItem{
+		Name:              s.GetName(),
+		Namespace:         s.GetNamespace(),
+		Type:              string(s.Type),
+		CreationTimestamp: s.GetCreationTimestamp().Time.Format(time.RFC3339Nano),
+	}
+}
+
+func SecretFieldGetter(s corev1.Secret, field string) (string, bool) {
+	switch field {
+	case "name":
+		return s.GetName(), true
+	case "namespace":
+		return s.GetNamespace(), true
+	case "type":
+		return string(s.Type), true
+	case "creationTimestamp":
+		return s.GetCreationTimestamp().Time.Format(time.RFC3339Nano), true
+	default:
+		return "", false
+	}
+}
+
+func SecretComparators() map[string]listutil.Comparator[corev1.Secret] {
+	return map[string]listutil.Comparator[corev1.Secret]{
+		"name": func(a, b corev1.Secret) int {
+			if a.GetName() < b.GetName() {
+				return -1
+			}
+			if a.GetName() > b.GetName() {
+				return 1
+			}
+			return 0
+		},
+		"creationTimestamp": func(a, b corev1.Secret) int {
+			at := a.GetCreationTimestamp().Time
+			bt := b.GetCreationTimestamp().Time
+			if at.Before(bt) {
+				return -1
+			}
+			if at.After(bt) {
+				return 1
+			}
+			return 0
+		},
+	}
+}
+
+var (
+	SortableFields   = map[string]struct{}{"name": {}, "creationTimestamp": {}}
+	FilterableFields = map[string]struct{}{"name": {}, "namespace": {}, "type": {}}
+)
+
+// GenerateMockSecrets creates mock resources for dev/testing.
+func GenerateMockSecrets(n int, namespace string) []corev1.Secret {
+	if n < 0 {
+		n = 0
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+	out := make([]corev1.Secret, 0, n)
+	now := time.Now().UTC()
+	for i := 1; i <= n; i++ {
+		s := corev1.Secret{}
+		s.SetName(fmt.Sprintf("mock-secret-%04d", i))
+		s.SetNamespace(namespace)
+		s.Type = corev1.SecretTypeOpaque
+		s.SetCreationTimestamp(metav1.NewTime(now.Add(-time.Duration(i) * time.Minute)))
+		out = append(out, s)
+	}
+	return out
+}

--- a/modules/common/errors/handler.go
+++ b/modules/common/errors/handler.go
@@ -24,7 +24,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// NewBadRequest creates a BadRequest error with message
+func NewBadRequest(message string) error {
+	return k8serrors.NewBadRequest(message)
+}
+
 func HandleError(err error) (int, error) {
+	if k8serrors.IsBadRequest(err) {
+		return http.StatusBadRequest, k8serrors.NewBadRequest(err.Error())
+	}
 	if k8serrors.IsUnauthorized(err) {
 		return http.StatusUnauthorized, k8serrors.NewUnauthorized("Unauthorized")
 	}

--- a/modules/web/src/api/configMap.ts
+++ b/modules/web/src/api/configMap.ts
@@ -1,14 +1,24 @@
 import { useQuery } from '@/hook/useQuery';
 import { Status } from '@/types/common';
-import { ConfigMap, ConfigMapList } from '@/types/configMap';
+import { ConfigMap } from '@/types/configMap';
 import { request } from '@/helper/request';
 
-
-export function useListConfigMaps(namespace?: string) {
-  const url = namespace ? `/configmap/${namespace}` : '/configmap';
-  return useQuery<ConfigMapList>('listConfigMaps', url, {
-    method: 'GET',
+export function useListConfigMaps(params?: Record<string, string | number | undefined>) {
+  let path = '/configmap';
+  // Optional namespace path parameter for compatibility
+  const namespace = params?.namespace as string | undefined;
+  if (namespace) {
+    path = `/configmap/${namespace}`;
+  }
+  const search = new URLSearchParams();
+  Object.entries(params || {}).forEach(([k, v]) => {
+    if (v !== undefined && v !== null && `${v}` !== '' && k !== 'namespace') {
+      search.set(k, String(v));
+    }
   });
+  const qs = search.toString();
+  if (qs) path += `?${qs}`;
+  return useQuery<any>(`listConfigMaps:${path}`, path, { method: 'GET' });
 }
 
 export function getConfigMap(namespace: string, name: string) {

--- a/modules/web/src/api/secret.ts
+++ b/modules/web/src/api/secret.ts
@@ -1,13 +1,24 @@
 import { useQuery } from '@/hook/useQuery';
 import { Status } from '@/types/common';
-import { Secret, SecretList } from '@/types/secret';
+import { Secret } from '@/types/secret';
 import { request } from '@/helper/request';
 
-export function useListSecrets(namespace?: string) {
-  const url = namespace ? `/secret/${namespace}` : '/secret';
-  return useQuery<SecretList>('listSecrets', url, {
-    method: 'GET',
+export function useListSecrets(params?: Record<string, string | number | undefined>) {
+  let path = '/secret';
+  // Optional namespace path parameter for compatibility
+  const namespace = params?.namespace as string | undefined;
+  if (namespace) {
+    path = `/secret/${namespace}`;
+  }
+  const search = new URLSearchParams();
+  Object.entries(params || {}).forEach(([k, v]) => {
+    if (v !== undefined && v !== null && `${v}` !== '' && k !== 'namespace') {
+      search.set(k, String(v));
+    }
   });
+  const qs = search.toString();
+  if (qs) path += `?${qs}`;
+  return useQuery<any>(`listSecrets:${path}`, path, { method: 'GET' });
 }
 
 export function getSecret(namespace: string, name: string) {

--- a/modules/web/src/app/configMap/page.tsx
+++ b/modules/web/src/app/configMap/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { ColumnDefinition, TableCard } from '@/component/TableCard';
-import { Box, TextField, Button } from '@mui/material';
+import { Box, TextField, Button, MenuItem, Pagination } from '@mui/material';
 import { createConfigMap, deleteConfigMap, getConfigMap, useListConfigMaps } from '@/api/configMap';
 import { ConfigMap } from '@/types/configMap';
 import { useNamespace } from '@/hook/useNamespace';
@@ -11,22 +11,22 @@ import ConfigmapDetailDialog from '@/component/ConfigmapDetailDialog';
 import useConfirmDialog from '@/hook/useConfirmDialog';
 import { useAlert } from '@/hook/useAlert';
 
-const columns: ColumnDefinition<ConfigMap>[] = [
+const columns: ColumnDefinition<ConfigMap | any>[] = [
   {
     name: 'Namespace',
-    render: (configMap) => configMap?.metadata?.namespace,
+    render: (configMap) => (configMap as any)?.metadata?.namespace ?? (configMap as any)?.namespace,
   },
   {
     name: 'Name',
-    render: (configMap) => configMap?.metadata?.name,
+    render: (configMap) => (configMap as any)?.metadata?.name ?? (configMap as any)?.name,
   },
   {
     name: 'Labels',
-    render: (configMap) => JSON.stringify(configMap.metadata?.labels),
+    render: (configMap) => JSON.stringify((configMap as any)?.metadata?.labels ?? (configMap as any)?.labels),
   },
   {
     name: 'Creation time',
-    render: (configMap) => configMap.metadata?.creationTimestamp,
+    render: (configMap) => (configMap as any)?.metadata?.creationTimestamp ?? (configMap as any)?.creationTimestamp,
   },
   {
     name: 'Operation',
@@ -35,13 +35,28 @@ const columns: ColumnDefinition<ConfigMap>[] = [
 ];
 
 export default function ConfigmapPage() {
-  const [dialogOpen, setDialogOpen] = React.useState(false);
-  const [detailDialogOpen, setDetailDialogOpen] = React.useState(false);
-  const [selectedConfigMap, setSelectedConfigMap] = React.useState<ConfigMap | null>(null);
   const { namespace } = useNamespace();
-  const { data, mutate } = useListConfigMaps(namespace);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
+  const [sort, setSort] = useState<string | undefined>('creationTimestamp');
+  const [order, setOrder] = useState<'asc' | 'desc' | undefined>('desc');
+  const [name, setName] = useState<string | undefined>(undefined);
+  const [mock, setMock] = useState<number | undefined>(undefined);
+  const params = useMemo(() => ({
+    namespace,
+    page,
+    pageSize,
+    sort,
+    order,
+    filter: [name ? `name:${name}` : undefined].filter(Boolean).join(','),
+    mock,
+  }), [namespace, page, pageSize, sort, order, name, mock]);
+  const { data, mutate } = useListConfigMaps(params);
   const { showConfirmDialog, ConfirmDialogComponent } = useConfirmDialog();
   const { setErrorMessage } = useAlert();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [detailDialogOpen, setDetailDialogOpen] = useState(false);
+  const [selectedConfigMap, setSelectedConfigMap] = useState<ConfigMap | null>(null);
 
   useEffect(() => {
     mutate();
@@ -109,8 +124,37 @@ export default function ConfigmapPage() {
           onDeleteClick={handleDelete}
           detailButtonLabel="Details"
           deleteButtonLabel="Delete"
-          specialHandling={false}
+          noPagination={true}
         />
+        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', marginTop: 2, flexWrap: 'wrap' }}>
+          <TextField size="small" select label="Rows per page" value={pageSize}
+            onChange={(e) => { const v = Number(e.target.value)||10; setPageSize(v); setPage(1); mutate(); }} sx={{ minWidth: 140 }}>
+            <MenuItem value={5}>5</MenuItem>
+            <MenuItem value={10}>10</MenuItem>
+            <MenuItem value={20}>20</MenuItem>
+            <MenuItem value={50}>50</MenuItem>
+          </TextField>
+          <TextField size="small" select label="Sort" value={sort||''} onChange={(e) => setSort(e.target.value||undefined)} sx={{ minWidth: 180 }}>
+            <MenuItem value="">Default</MenuItem>
+            <MenuItem value="name">name</MenuItem>
+            <MenuItem value="creationTimestamp">creationTimestamp</MenuItem>
+          </TextField>
+          <TextField size="small" select label="Order" value={order||''} onChange={(e) => setOrder((e.target.value as any)||undefined)} sx={{ minWidth: 140 }}>
+            <MenuItem value="">Default</MenuItem>
+            <MenuItem value="asc">asc</MenuItem>
+            <MenuItem value="desc">desc</MenuItem>
+          </TextField>
+          <TextField size="small" label="Name" value={name||''} onChange={(e) => setName(e.target.value||undefined)} placeholder="supports * wildcards" />
+          {/* mock control removed in PR branch; automatic fetch on change, no apply button */}
+          <Box sx={{ flexGrow: 1 }} />
+          <Pagination
+            page={page}
+            onChange={(_, value) => { setPage(value); mutate(); }}
+            count={Math.max(1, Math.ceil(((data?.total ?? 0) as number) / (pageSize || 1)))}
+            size="small"
+            color="primary"
+          />
+        </Box>
       </Box>
       <AddConfigmapDialog open={dialogOpen} onClose={handleCloseDialog} onSubmit={handleSubmit} />
       <ConfigmapDetailDialog open={detailDialogOpen} onClose={handleCloseDetailDialog} data={selectedConfigMap} />

--- a/modules/web/src/app/secret/page.tsx
+++ b/modules/web/src/app/secret/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React from 'react';
-import { Box } from '@mui/material';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Box, TextField, MenuItem, Pagination } from '@mui/material';
 import { createSecret, deleteSecret, getSecret, useListSecrets } from '@/api/secret';
 import { Secret } from '@/types/secret';
 import { useNamespace } from '@/hook/useNamespace';
@@ -11,22 +11,22 @@ import SecretDetailDialog from '@/component/SecretDetailDialog';
 import useConfirmDialog from '@/hook/useConfirmDialog';
 import { useAlert } from '@/hook/useAlert';
 
-const columns: ColumnDefinition<Secret>[] = [
+const columns: ColumnDefinition<Secret | any>[] = [
   {
     name: 'Namespace',
-    render: (secret) => secret?.metadata?.namespace,
+    render: (secret) => (secret as any)?.metadata?.namespace ?? (secret as any)?.namespace,
   },
   {
     name: 'Name',
-    render: (secret) => secret?.metadata?.name,
+    render: (secret) => (secret as any)?.metadata?.name ?? (secret as any)?.name,
   },
   {
     name: 'Type',
-    render: (secret) => secret.type,
+    render: (secret) => (secret as any)?.type ?? (secret as any)?.secretType,
   },
   {
     name: 'Creation time',
-    render: (secret) => secret.metadata?.creationTimestamp,
+    render: (secret) => (secret as any)?.metadata?.creationTimestamp ?? (secret as any)?.creationTimestamp,
   },
   {
     name: 'Operation',
@@ -36,15 +36,30 @@ const columns: ColumnDefinition<Secret>[] = [
 
 export default function SecretPage() {
   const { namespace } = useNamespace();
-  const { data, mutate } = useListSecrets(namespace);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
+  const [sort, setSort] = useState<string | undefined>('creationTimestamp');
+  const [order, setOrder] = useState<'asc' | 'desc' | undefined>('desc');
+  const [name, setName] = useState<string | undefined>(undefined);
+  const [mock, setMock] = useState<number | undefined>(undefined);
+  const params = useMemo(() => ({
+    namespace,
+    page,
+    pageSize,
+    sort,
+    order,
+    filter: [name ? `name:${name}` : undefined].filter(Boolean).join(','),
+    mock,
+  }), [namespace, page, pageSize, sort, order, name, mock]);
+  const { data, mutate } = useListSecrets(params);
 
-  const [openAddDialog, setOpenAddDialog] = React.useState(false);
-  const [openDetailDialog, setOpenDetailDialog] = React.useState(false);
-  const [selectedSecret, setSelectedSecret] = React.useState<Secret | null>(null);
+  const [openAddDialog, setOpenAddDialog] = useState(false);
+  const [openDetailDialog, setOpenDetailDialog] = useState(false);
+  const [selectedSecret, setSelectedSecret] = useState<Secret | null>(null);
   const { showConfirmDialog, ConfirmDialogComponent } = useConfirmDialog();
   const { setErrorMessage } = useAlert();
 
-  React.useEffect(() => {
+  useEffect(() => {
     mutate();
   }, [namespace, mutate]);
 
@@ -101,7 +116,37 @@ export default function SecretPage() {
           onDeleteClick={handleDeleteClick}
           detailButtonLabel="Details"
           deleteButtonLabel="Delete"
+          noPagination={true}
         />
+        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', marginTop: 2, flexWrap: 'wrap' }}>
+          <TextField size="small" select label="Rows per page" value={pageSize}
+            onChange={(e) => { const v = Number(e.target.value)||10; setPageSize(v); setPage(1); mutate(); }} sx={{ minWidth: 140 }}>
+            <MenuItem value={5}>5</MenuItem>
+            <MenuItem value={10}>10</MenuItem>
+            <MenuItem value={20}>20</MenuItem>
+            <MenuItem value={50}>50</MenuItem>
+          </TextField>
+          <TextField size="small" select label="Sort" value={sort||''} onChange={(e) => setSort(e.target.value||undefined)} sx={{ minWidth: 180 }}>
+            <MenuItem value="">Default</MenuItem>
+            <MenuItem value="name">name</MenuItem>
+            <MenuItem value="creationTimestamp">creationTimestamp</MenuItem>
+          </TextField>
+          <TextField size="small" select label="Order" value={order||''} onChange={(e) => setOrder((e.target.value as any)||undefined)} sx={{ minWidth: 140 }}>
+            <MenuItem value="">Default</MenuItem>
+            <MenuItem value="asc">asc</MenuItem>
+            <MenuItem value="desc">desc</MenuItem>
+          </TextField>
+          <TextField size="small" label="Name" value={name||''} onChange={(e) => setName(e.target.value||undefined)} placeholder="supports * wildcards" />
+          {/* mock control removed in PR branch; automatic fetch on change, no apply button */}
+          <Box sx={{ flexGrow: 1 }} />
+          <Pagination
+            page={page}
+            onChange={(_, value) => { setPage(value); mutate(); }}
+            count={Math.max(1, Math.ceil(((data?.total ?? 0) as number) / (pageSize || 1)))}
+            size="small"
+            color="primary"
+          />
+        </Box>
       </Box>
       <AddSecretDialog open={openAddDialog} onClose={() => setOpenAddDialog(false)} onSubmit={handleOnSubmit} />
       <SecretDetailDialog open={openDetailDialog} onClose={() => setOpenDetailDialog(false)} data={selectedSecret} />

--- a/modules/web/src/app/sse/keink/route.ts
+++ b/modules/web/src/app/sse/keink/route.ts
@@ -3,10 +3,6 @@ import { NextRequest } from 'next/server';
 export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest) {
-  if (!process.env.API_SERVER) {
-    return new Response('API_SERVER is not defined', { status: 500 });
-  }
-
   const { readable, writable } = new TransformStream();
   const writer = writable.getWriter();
   const encoder = new TextEncoder();

--- a/modules/web/src/component/AddServiceAccountDialog/index.tsx
+++ b/modules/web/src/component/AddServiceAccountDialog/index.tsx
@@ -18,7 +18,7 @@ const AddServiceAccountDialog = ({ open, onClose, onSubmit }: AddServiceAccountD
   const [secrets, setSecrets] = React.useState<string[]>([]);
   const [formErrors, setFormErrors] = React.useState<any>({});
   const namespaceData = useListNamespaces()?.data;
-  const { data, mutate } = useListSecrets(namespace);
+  const { data, mutate } = useListSecrets({ namespace });
   const { setErrorMessage } = useAlert();
 
   useEffect(() => {

--- a/modules/web/src/component/DeploymentDrawer/index.tsx
+++ b/modules/web/src/component/DeploymentDrawer/index.tsx
@@ -25,8 +25,8 @@ export default function DeploymentDrawer({ open, onClose, onSubmit }: Deployment
   const [activeStep, setActiveStep] = useState(0);
   const { setErrorMessage } = useAlert();
   const [data, setData] = useState<any>({});
-  const { data: configMaps, mutate: configMapMutate } = useListConfigMaps(namespace);
-  const { data: secrets, mutate: secretMutate } = useListSecrets(namespace);
+  const { data: configMaps, mutate: configMapMutate } = useListConfigMaps({ namespace });
+  const { data: secrets, mutate: secretMutate } = useListSecrets({ namespace });
   const { data: namespaces } = useListNamespaces();
 
   useEffect(() => {

--- a/modules/web/src/middleware.ts
+++ b/modules/web/src/middleware.ts
@@ -31,7 +31,8 @@ async function handleApiProxy(req: NextRequest) {
       headers[key] = value
     });
     const path = req.nextUrl.pathname.replace('/api/', '/api/v1/')
-    const url = new URL(path, process.env.API_SERVER);
+    const search = req.nextUrl.search || ''
+    const url = new URL(path + search, process.env.API_SERVER);
 
     const resp = await fetch(url, {
       method: req.method,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/dashboard/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind feature
/kind api-change

**What this PR does / why we need it**:

This PR implements the new unified list query, pagination, sorting, and filtering system for ConfigMaps and Secrets, following the same pattern established in PR1 (node-suite) and PR2 (application-suite).

**Backend Changes:**
- Add unified `ListQuery` parameter parsing for ConfigMaps and Secrets handlers
- Implement `ListResponse` with pagination metadata (total, page, pageSize, hasNext)
- Create resource-specific transform logic in `transform.go` files:
  - `ConfigMapListItem` DTO with projection, field getters, and comparators
  - `SecretListItem` DTO with projection, field getters, and comparators
- Support server-side filtering, sorting, and pagination using `listutil` functions
- Add mock data generation for development/testing

**Frontend Changes:**
- Replace old TableCard pagination with new unified pagination controls
- Add state management for page, pageSize, sort, order, and filter parameters
- Implement new MUI-based pagination UI with dropdowns and navigation
- Update API hooks to accept query parameters object instead of single namespace
- Fix component compatibility (DeploymentDrawer, AddServiceAccountDialog)

**Key Features:**
- Consistent pagination UI across all resource types
- Server-side filtering with wildcard support (`name:*pattern*`)
- Configurable page sizes (5, 10, 20, 50)
- Sortable by name and creationTimestamp
- Ascending/descending order support
- Optimized frontend-backend communication (only sends necessary fields)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

This PR completes the config suite (ConfigMaps + Secrets) following the established architectural pattern from foundation/PR1/PR2. All three PRs (node-suite, application-suite, config-suite) can be merged without conflicts as verified by merge simulation.

The implementation maintains backward compatibility while introducing the new pagination system. Mock data generation is available via `?mock=N` query parameter for development purposes.

**Does this PR introduce a user-facing change?**:

```release-note
ConfigMaps and Secrets pages now feature improved pagination, sorting, and filtering controls. Users can now:
- Configure page size (5/10/20/50 items per page)
- Sort by name or creation timestamp in ascending/descending order
- Filter resources by name with wildcard support
- Navigate through pages with improved pagination controls
- Experience faster loading with optimized data transfer
```