### PR TITLE
web: improve login form UX (paste, visibility, Enter submit)

### DIFF
--- a/modules/web/src/app/login/page.tsx
+++ b/modules/web/src/app/login/page.tsx
@@ -1,8 +1,11 @@
 'use client'
 
 import React, { useEffect, useState } from 'react';
-import { Box, Typography, TextField, Button, Link } from '@mui/material';
+import { Box, Typography, TextField, Button, Link, IconButton, InputAdornment } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import ContentPasteIcon from '@mui/icons-material/ContentPaste';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import { getVersion } from '@/api/version';
 import { useStorage } from '@/hook/useStorage';
@@ -17,6 +20,7 @@ import { useI18n } from '@/hook/useI18n';
 const LoginPage = () => {
   const [token, setToken] = useState('');
   const [tokenError, setTokenError] = useState('');
+  const [showToken, setShowToken] = useState(false);
   const [storedToken, setStoredToken] = useStorage('token');
   const [cookie, setCookie] = useCookie('dashboard_user');
   const { error } = useAlert();
@@ -54,6 +58,16 @@ const LoginPage = () => {
       error(e?.response?.data?.message || e?.message || t('messages.error'));
       setTokenError('Invalid token');
     }
+  };
+
+  const handlePaste = async () => {
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard && typeof navigator.clipboard.readText === 'function') {
+        const text = await navigator.clipboard.readText();
+        setToken(text || '');
+        setTokenError('');
+      }
+    } catch (_) {}
   };
 
   const handleRunKeink = () => {
@@ -104,13 +118,25 @@ const LoginPage = () => {
       <TextField
         variant="outlined"
         placeholder={t('messages.pleaseEnterToken')}
+        type={showToken ? 'text' : 'password'}
         InputProps={{
           startAdornment: (
             <PersonIcon sx={{ marginRight: '8px', color: 'gray' }} />
           ),
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton aria-label="paste token" onClick={handlePaste} edge="end">
+                <ContentPasteIcon />
+              </IconButton>
+              <IconButton aria-label="toggle token visibility" onClick={() => setShowToken(!showToken)} edge="end">
+                {showToken ? <VisibilityOffIcon /> : <VisibilityIcon />}
+              </IconButton>
+            </InputAdornment>
+          ),
         }}
         value={token}
-        onChange={(e) => setToken(e.target.value)}
+        onChange={(e) => { setToken(e.target.value); if (tokenError) setTokenError(''); }}
+        onKeyDown={(e) => { if (e.key === 'Enter') handleLogin(); }}
         error={!!tokenError}
         helperText={tokenError}
         sx={{


### PR DESCRIPTION
Type:
   kind feature
What this PR does / why we need it
   Improves the login page UX by adding clipboard paste for token, show/hide token visibility, and Enter-to-submit. This reduces friction for operators without touching global request/middleware logic.
Special notes for your reviewer
  UI-only change in the login page; no backend or API contracts affected. Scope limited to modules/web/src/app/login/page.tsx.
Which issue(s) this PR fixes
  NONE
Release note
  Enhance login form usability 
  with paste, visibility toggle, 
  and Enter-to-submit