### PR TITLE
feat(web): add about dialog

### DIFF
--- a/modules/web/src/component/Common/AppHeader/index.tsx
+++ b/modules/web/src/component/Common/AppHeader/index.tsx
@@ -16,6 +16,7 @@ import useCookie from '@/hook/useCookie';
 import { redirect } from 'next/navigation';
 import LanguageSwitcher from '@/component/LanguageSwitcher';
 import { useI18n } from '@/hook/useI18n';
+import AboutDialog from '@/component/Dialog/AboutDialog';
 
 const CustomSelect = styled(Select)(({ theme }) => ({
   height: 32,
@@ -50,6 +51,11 @@ export const AppHeader = () => {
 
   const handleClose = () => {
     setAnchorEl(null);
+  };
+
+  const handleAbout = () => {
+    setOpenAbout(true);
+    handleClose();
   };
 
   const handleLogout = () => {
@@ -115,10 +121,12 @@ export const AppHeader = () => {
             open={Boolean(anchorEl)}
             onClose={handleClose}
           >
+            <MenuItem onClick={handleAbout}>{t('common.about')}</MenuItem>
             <MenuItem onClick={handleLogout}>{t('common.logout')}</MenuItem>
           </Menu>
         </Box>
       </Toolbar>
+      <AboutDialog open={openAbout} onClose={() => setOpenAbout(false)} />
     </AppBar>
   );
 };

--- a/modules/web/src/component/Dialog/AboutDialog/index.tsx
+++ b/modules/web/src/component/Dialog/AboutDialog/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, Typography, Link, Stack } from '@mui/material';
+import Image from 'next/image';
+import { useI18n } from '@/hook/useI18n';
+
+interface AboutDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const AboutDialog = ({ open, onClose }: AboutDialogProps) => {
+  const { t } = useI18n();
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{t('common.about')}</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 2 }}>
+          <Image src="/icons/favicon.png" alt="KubeEdge" width={64} height={64} style={{ marginBottom: 16 }} />
+          <Typography variant="h6" gutterBottom>
+            KubeEdge {t('common.dashboard')}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" align="center" paragraph>
+            {t('common.aboutDescription')}
+          </Typography>
+          <Stack spacing={1} alignItems="center">
+            <Link href="https://kubeedge.io" target="_blank" rel="noopener noreferrer">
+              {t('common.website')}
+            </Link>
+            <Link href="https://github.com/kubeedge/dashboard" target="_blank" rel="noopener noreferrer">
+              {t('common.github')}
+            </Link>
+          </Stack>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="primary">
+          {t('actions.close')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default AboutDialog;

--- a/modules/web/src/locale/en.json
+++ b/modules/web/src/locale/en.json
@@ -27,7 +27,11 @@
     "language": "Language",
     "english": "English",
     "chinese": "中文",
-    "allNamespaces": "All Namespaces"
+    "allNamespaces": "All Namespaces",
+    "about": "About",
+    "aboutDescription": "A web-based UI for managing KubeEdge clusters.",
+    "website": "Official Website",
+    "github": "GitHub"
   },
   "actions": {
     "add": "Add",
@@ -48,6 +52,7 @@
     "generateCommand": "Generate Command",
     "yaml": "YAML",
     "ok": "Ok",
+    "close": "Close",
     "detail": "Detail",
     "copyYAML": "Copy YAML",
     "downloadYAML": "Download YAML",

--- a/modules/web/src/locale/zh.json
+++ b/modules/web/src/locale/zh.json
@@ -27,7 +27,11 @@
     "language": "语言",
     "english": "English",
     "chinese": "中文",
-    "allNamespaces": "所有命名空间"
+    "allNamespaces": "所有命名空间",
+    "about": "关于",
+    "aboutDescription": "用于管理 KubeEdge 集群的 Web 界面。",
+    "website": "官方网站",
+    "github": "GitHub"
   },
   "actions": {
     "add": "添加",
@@ -48,6 +52,7 @@
     "generateCommand": "生成命令",
     "yaml": "YAML",
     "ok": "确定",
+    "close": "关闭",
     "detail": "详情",
     "copyYAML": "复制 YAML",
     "downloadYAML": "下载 YAML",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an "About" dialog to the KubeEdge Dashboard, accessible via the user profile dropdown menu in the top navigation bar. It provides users with quick access to project information and official links.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # (None)

**Special notes for your reviewer**:
The changes include:
1. Created a new `AboutDialog` component displaying the logo, description, and links.
2. Integrated the "About" menu item into the `AppHeader` user dropdown.
3. Added i18n support (English and Chinese) for the new dialog.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
web: add "About" dialog to user profile menu
```

**How to test**:
1. Login to the dashboard.
2. Click on the username/avatar in the top right corner.
3. Click "About" (or "关于") in the dropdown menu.
4. Verify the dialog opens with the correct KubeEdge logo and links.