### PR TITLE
fix(api): validate list pagination bounds

### DIFF
--- a/modules/api/pkg/handler/query.go
+++ b/modules/api/pkg/handler/query.go
@@ -83,6 +83,11 @@ func parseListQueryFromValues(values url.Values, allowed AllowedFields) (ListQue
 		out.PageSize = defaultPageSize
 	}
 
+	maxPage := int(^uint(0)>>1) / out.PageSize
+	if out.Page > maxPage {
+		return ListQuery{}, k8serrors.NewBadRequest("invalid page: page * pageSize exceeds maximum integer")
+	}
+
 	// sort/order
 	sort := strings.TrimSpace(values.Get("sort"))
 	if sort != "" {

--- a/modules/api/pkg/handler/query_test.go
+++ b/modules/api/pkg/handler/query_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"net/url"
+	"testing"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func TestParseListQueryRejectsPageOverflow(t *testing.T) {
+	_, err := parseListQueryFromValues(url.Values{
+		"page":     {"9223372036854775807"},
+		"pageSize": {"200"},
+	}, AllowedFields{})
+	if !k8serrors.IsBadRequest(err) {
+		t.Fatalf("parseListQueryFromValues() error = %v, want BadRequest", err)
+	}
+}


### PR DESCRIPTION
## Description:

List-query parsing accepted every positive `page` value. Large page values can overflow pagination offset calculation before slicing the result list.

This PR fixes the issue in the minimal correct way:
- reject `page` values where `page * pageSize` exceeds the platform integer range
- add a focused test for `page=9223372036854775807&pageSize=200`

The change is limited to list-query validation and its unit test.

## Validation:

- `go test ./...` in `modules/api`
- `go vet ./...` in `modules/api`

## Checklist:

- [x] I updated only `modules/api/pkg/handler/query.go` and `modules/api/pkg/handler/query_test.go`.
- [x] I verified overflow input returns a BadRequest response.

## Release note:

```release-note
NONE
```