### PR TITLE
docs: add Windows setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,43 @@ API_SERVER={api module address} pnpm run start
 Example: API_SERVER=http://127.0.0.1:8080 pnpm run dev
 ```
 
+### Windows
+
+Install Go 1.23 and Node.js 18.17 or later before running the following commands.
+
+Start the backend from Command Prompt:
+
+```cmd
+cd modules\api
+go mod download
+go run main.go --apiserver-host=https://192.168.33.129:6443
+```
+
+In a second Command Prompt window, start the frontend:
+
+```cmd
+cd modules\web
+npm install
+set "API_SERVER=http://127.0.0.1:8080" && npm run dev
+```
+
+The equivalent commands in PowerShell are:
+
+```powershell
+Set-Location modules/api
+go mod download
+go run main.go --apiserver-host=https://192.168.33.129:6443
+```
+
+In a second PowerShell window:
+
+```powershell
+Set-Location modules/web
+npm install
+$env:API_SERVER = "http://127.0.0.1:8080"
+npm run dev
+```
+
 ### Login with token
 
 ```bash


### PR DESCRIPTION
## Description:

Fixes #44.

Issue #44 reported that the README only documents POSIX-style setup commands. Windows users therefore cannot directly use the documented module paths or inline `API_SERVER` assignment.

This PR fixes the documentation in the minimal way:
- add Command Prompt commands for backend and frontend dependency setup and startup
- add equivalent PowerShell commands
- state the Go and Node.js versions required by the current modules

The change is limited to `README.md`.

## Validation:

- `go mod download` in `modules/api`
- `go run main.go --help` in `modules/api`
- `go test ./pkg/args` in `modules/api`
- `npm install --package-lock=false --ignore-scripts --no-audit --no-fund` in `modules/web`
- `npm run build` in `modules/web`
- `git diff --check`

## Checklist:

- [x] I updated only `README.md`.
- [x] I verified the backend and frontend setup commands from their documented module directories.

## Release note:

```release-note
NONE
```